### PR TITLE
Add expired JWT test

### DIFF
--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/security/JwtTokenProvider.java
@@ -10,10 +10,17 @@ import java.util.Date;
 @Component
 public class JwtTokenProvider {
 
-    private final long validityInMilliseconds = 3600000; // 1 hora
-
+    private final long validityInMilliseconds;
     // Corregido a SecretKey para compatibilidad correcta con verifyWith()
     private final SecretKey secretKey = Jwts.SIG.HS256.key().build();
+
+    public JwtTokenProvider() {
+        this.validityInMilliseconds = 3600000; // 1 hora
+    }
+
+    public JwtTokenProvider(long validityInMilliseconds) {
+        this.validityInMilliseconds = validityInMilliseconds;
+    }
 
     public String generateToken(String nombreUsuario) {
         Date now = new Date();

--- a/backend/src/test/java/com/proyecto/erpventas/infrastructure/security/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/proyecto/erpventas/infrastructure/security/JwtTokenProviderTest.java
@@ -23,4 +23,16 @@ public class JwtTokenProviderTest {
             .isInstanceOf(RuntimeException.class)
             .hasMessageContaining("Token inválido o caducado");
     }
+
+    @Test
+    void deberiaLanzarExcepcionSiTokenEstaExpirado() throws InterruptedException {
+        JwtTokenProvider provider = new JwtTokenProvider(10); // 10 ms de validez
+        String token = provider.generateToken("usuarioDemo");
+
+        Thread.sleep(20); // esperar a que expire
+
+        assertThatThrownBy(() -> provider.validateToken(token))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("Token inválido o caducado");
+    }
 }


### PR DESCRIPTION
## Summary
- enable custom validity duration in `JwtTokenProvider`
- add test to ensure expired tokens are rejected

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684863e13b588324bea594fbc65e11dd