### PR TITLE
Implement Ventas listing

### DIFF
--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/venta/ListVentasUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/venta/ListVentasUseCase.java
@@ -1,0 +1,21 @@
+package com.proyecto.erpventas.application.usecases.venta;
+
+import com.proyecto.erpventas.domain.model.sales.Venta;
+import com.proyecto.erpventas.infrastructure.repository.venta.VentaRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ListVentasUseCase {
+
+    private final VentaRepository ventaRepository;
+
+    public ListVentasUseCase(VentaRepository ventaRepository) {
+        this.ventaRepository = ventaRepository;
+    }
+
+    public List<Venta> listAll() {
+        return ventaRepository.findAll();
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/controller/VentaController.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/controller/VentaController.java
@@ -1,0 +1,40 @@
+package com.proyecto.erpventas.infrastructure.controller;
+
+import com.proyecto.erpventas.application.dto.response.venta.VentaResponseDTO;
+import com.proyecto.erpventas.application.usecases.venta.ListVentasUseCase;
+import com.proyecto.erpventas.domain.model.sales.Venta;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/ventas")
+public class VentaController {
+
+    private final ListVentasUseCase listVentasUseCase;
+
+    public VentaController(ListVentasUseCase listVentasUseCase) {
+        this.listVentasUseCase = listVentasUseCase;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<VentaResponseDTO>> getAll() {
+        List<Venta> ventas = listVentasUseCase.listAll();
+        List<VentaResponseDTO> response = ventas.stream().map(v -> new VentaResponseDTO(
+                v.getVentaId(),
+                v.getCliente().getClienteId(),
+                v.getCliente().getNombre(),
+                v.getFechaVenta(),
+                v.getTotal(),
+                v.getMetodoPago().getMetodoPagoId(),
+                v.getMetodoPago().getNombre(),
+                v.getCreadoPorUsuario().getUsuarioID(),
+                v.getCreadoPorUsuario().getNombreUsuario(),
+                v.getActivo()
+        )).toList();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/frontend/src/app/core/models/ventas/detalle-venta.model.ts
+++ b/frontend/src/app/core/models/ventas/detalle-venta.model.ts
@@ -1,0 +1,10 @@
+export interface DetalleVenta {
+  detalleId: number;
+  ventaId: number;
+  productoId: number;
+  productoNombre: string;
+  cantidad: number;
+  precioUnitario: number;
+  subtotal: number;
+  activo: boolean;
+}

--- a/frontend/src/app/core/models/ventas/factura.model.ts
+++ b/frontend/src/app/core/models/ventas/factura.model.ts
@@ -1,0 +1,10 @@
+export interface Factura {
+  facturaId: number;
+  ventaId: number;
+  numeroFactura: string;
+  fechaEmision: string;
+  xmlFactura: string | null;
+  creadoPorUsuarioId: number;
+  creadoPorUsuarioNombre: string;
+  activo: boolean;
+}

--- a/frontend/src/app/core/models/ventas/venta.model.ts
+++ b/frontend/src/app/core/models/ventas/venta.model.ts
@@ -1,0 +1,12 @@
+export interface Venta {
+  ventaId: number;
+  clienteId: number;
+  clienteNombre: string;
+  fechaVenta: string;
+  total: number;
+  metodoPagoId: number;
+  metodoPagoNombre: string;
+  creadoPorUsuarioId: number;
+  creadoPorUsuarioNombre: string;
+  activo: boolean;
+}

--- a/frontend/src/app/features/ventas/components/ventas/ventas.component.html
+++ b/frontend/src/app/features/ventas/components/ventas/ventas.component.html
@@ -1,1 +1,45 @@
-<p>ventas works!</p>
+<section class="ventas-container">
+  <div class="summary-grid">
+    <app-summary-card
+      title="Total Ventas"
+      [value]="'Bs ' + (totalVentas | number:'1.2-2')"
+      icon="attach_money"
+      color="accent"></app-summary-card>
+    <app-summary-card
+      title="Registros"
+      [value]="ventas.length"
+      icon="description"
+      color="primary"></app-summary-card>
+  </div>
+
+  <div class="table-container" *ngIf="!loading; else loadingTpl">
+    <table mat-table [dataSource]="ventas" class="mat-elevation-z1">
+      <ng-container matColumnDef="ventaId">
+        <th mat-header-cell *matHeaderCellDef>ID</th>
+        <td mat-cell *matCellDef="let row">{{ row.ventaId }}</td>
+      </ng-container>
+      <ng-container matColumnDef="clienteNombre">
+        <th mat-header-cell *matHeaderCellDef>Cliente</th>
+        <td mat-cell *matCellDef="let row">{{ row.clienteNombre }}</td>
+      </ng-container>
+      <ng-container matColumnDef="fechaVenta">
+        <th mat-header-cell *matHeaderCellDef>Fecha</th>
+        <td mat-cell *matCellDef="let row">{{ row.fechaVenta | date:'short' }}</td>
+      </ng-container>
+      <ng-container matColumnDef="total">
+        <th mat-header-cell *matHeaderCellDef>Total</th>
+        <td mat-cell *matCellDef="let row">{{ row.total | currency:'USD':'symbol' }}</td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  </div>
+
+  <ng-template #loadingTpl>
+    <div class="loading-container">
+      <mat-spinner></mat-spinner>
+      <p>Cargando...</p>
+    </div>
+  </ng-template>
+</section>

--- a/frontend/src/app/features/ventas/components/ventas/ventas.component.scss
+++ b/frontend/src/app/features/ventas/components/ventas/ventas.component.scss
@@ -1,0 +1,30 @@
+.ventas-container {
+  padding: 1rem;
+
+  .summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+
+  .table-container {
+    overflow-x: auto;
+  }
+
+  .loading-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 200px;
+  }
+}
+
+table {
+  width: 100%;
+
+  th.mat-header-cell {
+    font-weight: bold;
+  }
+}

--- a/frontend/src/app/features/ventas/components/ventas/ventas.component.ts
+++ b/frontend/src/app/features/ventas/components/ventas/ventas.component.ts
@@ -1,12 +1,42 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableModule } from '@angular/material/table';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { SummaryCardComponent } from 'src/app/shared/components/summary-card/summary-card.component';
+import { VentasApiService } from 'src/app/infrastructure/api/ventas/ventas-api.service';
+import { Venta } from '@core/models/ventas/venta.model';
 
 @Component({
   selector: 'app-ventas',
   standalone: true,
-  imports: [],
+  imports: [CommonModule, MatTableModule, MatProgressSpinnerModule, SummaryCardComponent],
   templateUrl: './ventas.component.html',
   styleUrls: ['./ventas.component.scss']
 })
-export class VentasComponent {
+export class VentasComponent implements OnInit {
+  ventas: Venta[] = [];
+  loading = false;
+  displayedColumns = ['ventaId', 'clienteNombre', 'fechaVenta', 'total'];
+  totalVentas = 0;
 
+  constructor(private ventasApi: VentasApiService) {}
+
+  ngOnInit() {
+    this.cargarVentas();
+  }
+
+  private cargarVentas() {
+    this.loading = true;
+    this.ventasApi.obtenerVentas().subscribe({
+      next: (data) => {
+        this.ventas = data;
+        this.totalVentas = data.reduce((sum, v) => sum + Number(v.total), 0);
+        this.loading = false;
+      },
+      error: () => {
+        alert('No se pudieron cargar las ventas');
+        this.loading = false;
+      }
+    });
+  }
 }

--- a/frontend/src/app/infrastructure/api/ventas/ventas-api.service.ts
+++ b/frontend/src/app/infrastructure/api/ventas/ventas-api.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Venta } from '@core/models/ventas/venta.model';
+
+@Injectable({ providedIn: 'root' })
+export class VentasApiService {
+  private base = '/api/ventas';
+
+  constructor(private http: HttpClient) {}
+
+  obtenerVentas(): Observable<Venta[]> {
+    return this.http.get<Venta[]>(this.base);
+  }
+}


### PR DESCRIPTION
## Summary
- add ListVentasUseCase and VentaController in backend
- create Venta models for frontend and API service
- implement ventas component to display table with summary

## Testing
- `./mvnw test` *(fails: Network is unreachable)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ecac18f08324a441a156f663aed9