### PR TITLE
Implement ventas module

### DIFF
--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/venta/CreateVentaUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/venta/CreateVentaUseCase.java
@@ -1,0 +1,47 @@
+package com.proyecto.erpventas.application.usecases.venta;
+
+import com.proyecto.erpventas.application.dto.request.venta.CreateVentaDTO;
+import com.proyecto.erpventas.domain.model.inventory.MetodoPago;
+import com.proyecto.erpventas.domain.model.people.Cliente;
+import com.proyecto.erpventas.domain.model.people.Usuario;
+import com.proyecto.erpventas.domain.model.sales.Venta;
+import com.proyecto.erpventas.infrastructure.repository.cliente.ClienteRepository;
+import com.proyecto.erpventas.infrastructure.repository.metodo.MetodoPagoRepository;
+import com.proyecto.erpventas.infrastructure.repository.usuario.UserRepository;
+import com.proyecto.erpventas.infrastructure.repository.venta.VentaRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CreateVentaUseCase {
+
+    private final VentaRepository ventaRepository;
+    private final ClienteRepository clienteRepository;
+    private final MetodoPagoRepository metodoPagoRepository;
+    private final UserRepository userRepository;
+
+    public CreateVentaUseCase(VentaRepository ventaRepository,
+                              ClienteRepository clienteRepository,
+                              MetodoPagoRepository metodoPagoRepository,
+                              UserRepository userRepository) {
+        this.ventaRepository = ventaRepository;
+        this.clienteRepository = clienteRepository;
+        this.metodoPagoRepository = metodoPagoRepository;
+        this.userRepository = userRepository;
+    }
+
+    public Venta create(CreateVentaDTO dto) {
+        Cliente cliente = clienteRepository.findById(dto.getClienteId())
+                .orElseThrow(() -> new RuntimeException("Cliente no encontrado"));
+        MetodoPago metodo = metodoPagoRepository.findById(dto.getMetodoPagoId())
+                .orElseThrow(() -> new RuntimeException("Método de pago no encontrado"));
+        Usuario usuario = userRepository.findById(dto.getCreadoPorUsuarioId())
+                .orElseThrow(() -> new RuntimeException("Usuario creador no encontrado"));
+
+        Venta venta = new Venta();
+        venta.setCliente(cliente);
+        venta.setMetodoPago(metodo);
+        venta.setTotal(dto.getTotal());
+        venta.setCreadoPorUsuario(usuario);
+        return ventaRepository.save(venta);
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/venta/DeleteVentaUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/venta/DeleteVentaUseCase.java
@@ -1,0 +1,22 @@
+package com.proyecto.erpventas.application.usecases.venta;
+
+import com.proyecto.erpventas.domain.model.sales.Venta;
+import com.proyecto.erpventas.infrastructure.repository.venta.VentaRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DeleteVentaUseCase {
+
+    private final VentaRepository ventaRepository;
+
+    public DeleteVentaUseCase(VentaRepository ventaRepository) {
+        this.ventaRepository = ventaRepository;
+    }
+
+    public void delete(Integer id) {
+        Venta venta = ventaRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Venta no encontrada"));
+        venta.setActivo(false);
+        ventaRepository.save(venta);
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/venta/GetVentaByIdUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/venta/GetVentaByIdUseCase.java
@@ -1,0 +1,21 @@
+package com.proyecto.erpventas.application.usecases.venta;
+
+import com.proyecto.erpventas.domain.model.sales.Venta;
+import com.proyecto.erpventas.infrastructure.repository.venta.VentaRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class GetVentaByIdUseCase {
+
+    private final VentaRepository ventaRepository;
+
+    public GetVentaByIdUseCase(VentaRepository ventaRepository) {
+        this.ventaRepository = ventaRepository;
+    }
+
+    public Optional<Venta> getById(Integer id) {
+        return ventaRepository.findById(id);
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/venta/ListVentasUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/venta/ListVentasUseCase.java
@@ -1,0 +1,21 @@
+package com.proyecto.erpventas.application.usecases.venta;
+
+import com.proyecto.erpventas.domain.model.sales.Venta;
+import com.proyecto.erpventas.infrastructure.repository.venta.VentaRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ListVentasUseCase {
+
+    private final VentaRepository ventaRepository;
+
+    public ListVentasUseCase(VentaRepository ventaRepository) {
+        this.ventaRepository = ventaRepository;
+    }
+
+    public List<Venta> listAll() {
+        return ventaRepository.findAllByActivoTrue();
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/venta/UpdateVentaUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/venta/UpdateVentaUseCase.java
@@ -1,0 +1,31 @@
+package com.proyecto.erpventas.application.usecases.venta;
+
+import com.proyecto.erpventas.application.dto.request.venta.UpdateVentaDTO;
+import com.proyecto.erpventas.domain.model.inventory.MetodoPago;
+import com.proyecto.erpventas.domain.model.sales.Venta;
+import com.proyecto.erpventas.infrastructure.repository.metodo.MetodoPagoRepository;
+import com.proyecto.erpventas.infrastructure.repository.venta.VentaRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UpdateVentaUseCase {
+
+    private final VentaRepository ventaRepository;
+    private final MetodoPagoRepository metodoPagoRepository;
+
+    public UpdateVentaUseCase(VentaRepository ventaRepository,
+                              MetodoPagoRepository metodoPagoRepository) {
+        this.ventaRepository = ventaRepository;
+        this.metodoPagoRepository = metodoPagoRepository;
+    }
+
+    public Venta update(Integer id, UpdateVentaDTO dto) {
+        Venta existing = ventaRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Venta no encontrada"));
+        MetodoPago metodo = metodoPagoRepository.findById(dto.getMetodoPagoId())
+                .orElseThrow(() -> new RuntimeException("Método de pago no encontrado"));
+        existing.setMetodoPago(metodo);
+        existing.setTotal(dto.getTotal());
+        return ventaRepository.save(existing);
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/controller/VentaController.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/controller/VentaController.java
@@ -1,0 +1,83 @@
+package com.proyecto.erpventas.infrastructure.controller;
+
+import com.proyecto.erpventas.application.dto.request.venta.CreateVentaDTO;
+import com.proyecto.erpventas.application.dto.request.venta.UpdateVentaDTO;
+import com.proyecto.erpventas.application.dto.response.venta.VentaResponseDTO;
+import com.proyecto.erpventas.application.usecases.venta.*;
+import com.proyecto.erpventas.domain.model.sales.Venta;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/ventas")
+public class VentaController {
+
+    private final CreateVentaUseCase createUC;
+    private final ListVentasUseCase listUC;
+    private final GetVentaByIdUseCase getByIdUC;
+    private final UpdateVentaUseCase updateUC;
+    private final DeleteVentaUseCase deleteUC;
+
+    public VentaController(CreateVentaUseCase createUC,
+                           ListVentasUseCase listUC,
+                           GetVentaByIdUseCase getByIdUC,
+                           UpdateVentaUseCase updateUC,
+                           DeleteVentaUseCase deleteUC) {
+        this.createUC = createUC;
+        this.listUC = listUC;
+        this.getByIdUC = getByIdUC;
+        this.updateUC = updateUC;
+        this.deleteUC = deleteUC;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<VentaResponseDTO>> getAll() {
+        List<Venta> ventas = listUC.listAll();
+        List<VentaResponseDTO> response = ventas.stream().map(this::toDto).toList();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<VentaResponseDTO> getById(@PathVariable Integer id) {
+        Venta venta = getByIdUC.getById(id)
+                .orElseThrow(() -> new RuntimeException("Venta no encontrada"));
+        return ResponseEntity.ok(toDto(venta));
+    }
+
+    @PostMapping
+    public ResponseEntity<VentaResponseDTO> create(@Valid @RequestBody CreateVentaDTO dto) {
+        Venta created = createUC.create(dto);
+        return ResponseEntity.ok(toDto(created));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<VentaResponseDTO> update(@PathVariable Integer id,
+                                                   @Valid @RequestBody UpdateVentaDTO dto) {
+        Venta updated = updateUC.update(id, dto);
+        return ResponseEntity.ok(toDto(updated));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> delete(@PathVariable Integer id) {
+        deleteUC.delete(id);
+        return ResponseEntity.ok("Venta eliminada correctamente (borrado lógico)");
+    }
+
+    private VentaResponseDTO toDto(Venta v) {
+        return new VentaResponseDTO(
+                v.getVentaId(),
+                v.getCliente().getClienteId(),
+                v.getCliente().getNombre(),
+                v.getFechaVenta(),
+                v.getTotal(),
+                v.getMetodoPago().getMetodoPagoId(),
+                v.getMetodoPago().getNombre(),
+                v.getCreadoPorUsuario().getUsuarioID(),
+                v.getCreadoPorUsuario().getNombreUsuario(),
+                v.getActivo()
+        );
+    }
+}

--- a/frontend/src/app/core/models/ventas/detalle-venta.model.ts
+++ b/frontend/src/app/core/models/ventas/detalle-venta.model.ts
@@ -1,0 +1,10 @@
+export interface DetalleVenta {
+  detalleId: number;
+  ventaId: number;
+  productoId: number;
+  productoNombre: string;
+  cantidad: number;
+  precioUnitario: number;
+  subtotal: number;
+  activo: boolean;
+}

--- a/frontend/src/app/core/models/ventas/factura.model.ts
+++ b/frontend/src/app/core/models/ventas/factura.model.ts
@@ -1,0 +1,9 @@
+export interface Factura {
+  facturaId: number;
+  ventaId: number;
+  numeroFactura: string;
+  fechaEmision: string;
+  xmlFactura: string;
+  creadoPorUsuarioId: number;
+  activo: boolean;
+}

--- a/frontend/src/app/core/models/ventas/venta.model.ts
+++ b/frontend/src/app/core/models/ventas/venta.model.ts
@@ -1,0 +1,12 @@
+export interface Venta {
+  ventaId: number;
+  clienteId: number;
+  clienteNombre: string;
+  fechaVenta: string;
+  total: number;
+  metodoPagoId: number;
+  metodoPagoNombre: string;
+  creadoPorUsuarioId: number;
+  creadoPorUsuarioNombre: string;
+  activo: boolean;
+}

--- a/frontend/src/app/features/ventas/components/ventas/ventas.component.html
+++ b/frontend/src/app/features/ventas/components/ventas/ventas.component.html
@@ -1,1 +1,35 @@
-<p>ventas works!</p>
+<section class="ventas-container">
+  <h2>Ventas</h2>
+  <div class="table-container" *ngIf="!loading; else loadingTpl">
+    <table mat-table [dataSource]="ventas" class="mat-elevation-z1">
+      <ng-container matColumnDef="ventaId">
+        <th mat-header-cell *matHeaderCellDef>ID</th>
+        <td mat-cell *matCellDef="let v">{{ v.ventaId }}</td>
+      </ng-container>
+      <ng-container matColumnDef="clienteNombre">
+        <th mat-header-cell *matHeaderCellDef>Cliente</th>
+        <td mat-cell *matCellDef="let v">{{ v.clienteNombre }}</td>
+      </ng-container>
+      <ng-container matColumnDef="fechaVenta">
+        <th mat-header-cell *matHeaderCellDef>Fecha</th>
+        <td mat-cell *matCellDef="let v">{{ v.fechaVenta | date:'short' }}</td>
+      </ng-container>
+      <ng-container matColumnDef="total">
+        <th mat-header-cell *matHeaderCellDef>Total</th>
+        <td mat-cell *matCellDef="let v">{{ v.total | currency:'USD':'symbol' }}</td>
+      </ng-container>
+      <ng-container matColumnDef="metodoPago">
+        <th mat-header-cell *matHeaderCellDef>Método Pago</th>
+        <td mat-cell *matCellDef="let v">{{ v.metodoPagoNombre }}</td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  </div>
+  <ng-template #loadingTpl>
+    <div class="loading-container">
+      <mat-spinner></mat-spinner>
+      <p>Cargando ventas...</p>
+    </div>
+  </ng-template>
+</section>

--- a/frontend/src/app/features/ventas/components/ventas/ventas.component.scss
+++ b/frontend/src/app/features/ventas/components/ventas/ventas.component.scss
@@ -1,0 +1,27 @@
+.ventas-container {
+  padding: 1rem;
+
+  h2 {
+    margin-bottom: 1rem;
+  }
+
+  .table-container {
+    overflow-x: auto;
+  }
+
+  .loading-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 200px;
+  }
+}
+
+/* Ajustes tabla */
+table {
+  width: 100%;
+  th.mat-header-cell {
+    font-weight: bold;
+  }
+}

--- a/frontend/src/app/features/ventas/components/ventas/ventas.component.ts
+++ b/frontend/src/app/features/ventas/components/ventas/ventas.component.ts
@@ -1,12 +1,39 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableModule } from '@angular/material/table';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { VentasApiService } from 'src/app/infrastructure/api/ventas/ventas-api.service';
+import { Venta } from 'src/app/core/models/ventas/venta.model';
 
 @Component({
   selector: 'app-ventas',
   standalone: true,
-  imports: [],
+  imports: [CommonModule, MatTableModule, MatProgressSpinnerModule],
   templateUrl: './ventas.component.html',
   styleUrls: ['./ventas.component.scss']
 })
-export class VentasComponent {
+export class VentasComponent implements OnInit {
+  ventas: Venta[] = [];
+  displayedColumns = ['ventaId', 'clienteNombre', 'fechaVenta', 'total', 'metodoPago'];
+  loading = false;
 
+  constructor(private ventasApi: VentasApiService) {}
+
+  ngOnInit() {
+    this.cargarVentas();
+  }
+
+  private cargarVentas() {
+    this.loading = true;
+    this.ventasApi.obtenerVentas().subscribe({
+      next: (data) => {
+        this.ventas = data;
+        this.loading = false;
+      },
+      error: () => {
+        alert('No se pudieron cargar las ventas');
+        this.loading = false;
+      }
+    });
+  }
 }

--- a/frontend/src/app/infrastructure/api/ventas/ventas-api.service.ts
+++ b/frontend/src/app/infrastructure/api/ventas/ventas-api.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Venta } from '../../core/models/ventas/venta.model';
+
+@Injectable({ providedIn: 'root' })
+export class VentasApiService {
+  private baseUrl = '/api/ventas';
+
+  constructor(private http: HttpClient) {}
+
+  obtenerVentas(): Observable<Venta[]> {
+    return this.http.get<Venta[]>(this.baseUrl);
+  }
+}


### PR DESCRIPTION
## Summary
- add CRUD use cases for `Venta`
- create `VentaController` with basic endpoints
- define frontend models for ventas
- implement `VentasApiService` and show list in `VentasComponent`

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: `mvn` not found)*
- `npm test --prefix frontend` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fc7b08c88324bc66d342d9124afa