### PR TITLE
Add CategoriaProducto entity

### DIFF
--- a/backend/src/main/java/com/proyecto/erpventas/domain/model/inventory/CategoriaProducto.java
+++ b/backend/src/main/java/com/proyecto/erpventas/domain/model/inventory/CategoriaProducto.java
@@ -1,5 +1,26 @@
 package com.proyecto.erpventas.domain.model.inventory;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "CategoriasProducto")
+@Getter
+@Setter
 public class CategoriaProducto {
-    
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "categoriaid")
+    private Integer categoriaId;
+
+    @Column(name = "nombre", nullable = false)
+    private String nombre;
+
+    @Column(name = "descripcion")
+    private String descripcion;
+
+    @Column(name = "activo", nullable = false)
+    private Boolean activo = true;
 }


### PR DESCRIPTION
## Summary
- mark `CategoriaProducto` as a JPA entity and map to the table `CategoriasProducto`
- add fields `categoriaId`, `nombre`, `descripcion`, and `activo`
- use Lombok getters and setters

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684aafd25c1c8324a59f1a136969243e