### PR TITLE
Add category and product CRUD logic

### DIFF
--- a/backend/src/main/java/com/proyecto/erpventas/application/dto/request/categoria/CreateCategoriaDTO.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/dto/request/categoria/CreateCategoriaDTO.java
@@ -1,0 +1,15 @@
+package com.proyecto.erpventas.application.dto.request.categoria;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateCategoriaDTO {
+
+    @NotBlank
+    private String nombre;
+
+    private String descripcion;
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/dto/request/categoria/UpdateCategoriaDTO.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/dto/request/categoria/UpdateCategoriaDTO.java
@@ -1,0 +1,15 @@
+package com.proyecto.erpventas.application.dto.request.categoria;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UpdateCategoriaDTO {
+
+    @NotBlank
+    private String nombre;
+
+    private String descripcion;
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/dto/request/producto/CreateProductoDTO.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/dto/request/producto/CreateProductoDTO.java
@@ -22,4 +22,7 @@ public class CreateProductoDTO {
     @NotNull
     @Min(0)
     private Integer stock;
+
+    @NotNull
+    private Integer categoriaId;
 }

--- a/backend/src/main/java/com/proyecto/erpventas/application/dto/request/producto/UpdateProductoDTO.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/dto/request/producto/UpdateProductoDTO.java
@@ -22,4 +22,7 @@ public class UpdateProductoDTO {
     @NotNull
     @Min(0)
     private Integer stock;
+
+    @NotNull
+    private Integer categoriaId;
 }

--- a/backend/src/main/java/com/proyecto/erpventas/application/dto/response/categoria/CategoriaResponseDTO.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/dto/response/categoria/CategoriaResponseDTO.java
@@ -1,0 +1,15 @@
+package com.proyecto.erpventas.application.dto.response.categoria;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class CategoriaResponseDTO {
+    private Integer categoriaId;
+    private String nombre;
+    private String descripcion;
+    private Boolean activo;
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/dto/response/producto/ProductoResponseDTO.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/dto/response/producto/ProductoResponseDTO.java
@@ -15,5 +15,7 @@ public class ProductoResponseDTO {
     private String descripcion;
     private BigDecimal precio;
     private Integer stock;
+    private Integer categoriaId;
+    private String categoriaNombre;
     private Boolean activo;
 }

--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/categoria/CreateCategoriaUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/categoria/CreateCategoriaUseCase.java
@@ -1,0 +1,26 @@
+package com.proyecto.erpventas.application.usecases.categoria;
+
+import com.proyecto.erpventas.application.dto.request.categoria.CreateCategoriaDTO;
+import com.proyecto.erpventas.domain.model.inventory.CategoriaProducto;
+import com.proyecto.erpventas.infrastructure.repository.categoria.CategoriaProductoRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CreateCategoriaUseCase {
+
+    private final CategoriaProductoRepository categoriaRepository;
+
+    public CreateCategoriaUseCase(CategoriaProductoRepository categoriaRepository) {
+        this.categoriaRepository = categoriaRepository;
+    }
+
+    public CategoriaProducto create(CreateCategoriaDTO dto) {
+        if (categoriaRepository.existsByNombre(dto.getNombre())) {
+            throw new RuntimeException("Ya existe una categoría con ese nombre");
+        }
+        CategoriaProducto cat = new CategoriaProducto();
+        cat.setNombre(dto.getNombre());
+        cat.setDescripcion(dto.getDescripcion());
+        return categoriaRepository.save(cat);
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/categoria/DeleteCategoriaUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/categoria/DeleteCategoriaUseCase.java
@@ -1,0 +1,22 @@
+package com.proyecto.erpventas.application.usecases.categoria;
+
+import com.proyecto.erpventas.domain.model.inventory.CategoriaProducto;
+import com.proyecto.erpventas.infrastructure.repository.categoria.CategoriaProductoRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DeleteCategoriaUseCase {
+
+    private final CategoriaProductoRepository categoriaRepository;
+
+    public DeleteCategoriaUseCase(CategoriaProductoRepository categoriaRepository) {
+        this.categoriaRepository = categoriaRepository;
+    }
+
+    public void delete(Integer id) {
+        CategoriaProducto existing = categoriaRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Categoría no encontrada"));
+        existing.setActivo(false);
+        categoriaRepository.save(existing);
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/categoria/GetCategoriaByIdUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/categoria/GetCategoriaByIdUseCase.java
@@ -1,0 +1,21 @@
+package com.proyecto.erpventas.application.usecases.categoria;
+
+import com.proyecto.erpventas.domain.model.inventory.CategoriaProducto;
+import com.proyecto.erpventas.infrastructure.repository.categoria.CategoriaProductoRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class GetCategoriaByIdUseCase {
+
+    private final CategoriaProductoRepository categoriaRepository;
+
+    public GetCategoriaByIdUseCase(CategoriaProductoRepository categoriaRepository) {
+        this.categoriaRepository = categoriaRepository;
+    }
+
+    public Optional<CategoriaProducto> getById(Integer id) {
+        return categoriaRepository.findById(id);
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/categoria/ListCategoriasUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/categoria/ListCategoriasUseCase.java
@@ -1,0 +1,21 @@
+package com.proyecto.erpventas.application.usecases.categoria;
+
+import com.proyecto.erpventas.domain.model.inventory.CategoriaProducto;
+import com.proyecto.erpventas.infrastructure.repository.categoria.CategoriaProductoRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ListCategoriasUseCase {
+
+    private final CategoriaProductoRepository categoriaRepository;
+
+    public ListCategoriasUseCase(CategoriaProductoRepository categoriaRepository) {
+        this.categoriaRepository = categoriaRepository;
+    }
+
+    public List<CategoriaProducto> listAll() {
+        return categoriaRepository.findAllByActivoTrue();
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/categoria/UpdateCategoriaUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/categoria/UpdateCategoriaUseCase.java
@@ -1,0 +1,24 @@
+package com.proyecto.erpventas.application.usecases.categoria;
+
+import com.proyecto.erpventas.application.dto.request.categoria.UpdateCategoriaDTO;
+import com.proyecto.erpventas.domain.model.inventory.CategoriaProducto;
+import com.proyecto.erpventas.infrastructure.repository.categoria.CategoriaProductoRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UpdateCategoriaUseCase {
+
+    private final CategoriaProductoRepository categoriaRepository;
+
+    public UpdateCategoriaUseCase(CategoriaProductoRepository categoriaRepository) {
+        this.categoriaRepository = categoriaRepository;
+    }
+
+    public CategoriaProducto update(Integer id, UpdateCategoriaDTO dto) {
+        CategoriaProducto existing = categoriaRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Categoría no encontrada"));
+        existing.setNombre(dto.getNombre());
+        existing.setDescripcion(dto.getDescripcion());
+        return categoriaRepository.save(existing);
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/producto/CreateProductoUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/producto/CreateProductoUseCase.java
@@ -1,0 +1,36 @@
+package com.proyecto.erpventas.application.usecases.producto;
+
+import com.proyecto.erpventas.application.dto.request.producto.CreateProductoDTO;
+import com.proyecto.erpventas.domain.model.inventory.CategoriaProducto;
+import com.proyecto.erpventas.domain.model.inventory.Producto;
+import com.proyecto.erpventas.infrastructure.repository.categoria.CategoriaProductoRepository;
+import com.proyecto.erpventas.infrastructure.repository.producto.ProductoRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CreateProductoUseCase {
+
+    private final ProductoRepository productoRepository;
+    private final CategoriaProductoRepository categoriaRepository;
+
+    public CreateProductoUseCase(ProductoRepository productoRepository,
+                                 CategoriaProductoRepository categoriaRepository) {
+        this.productoRepository = productoRepository;
+        this.categoriaRepository = categoriaRepository;
+    }
+
+    public Producto create(CreateProductoDTO dto) {
+        if (productoRepository.existsByNombre(dto.getNombre())) {
+            throw new RuntimeException("Ya existe un producto con ese nombre");
+        }
+        CategoriaProducto categoria = categoriaRepository.findById(dto.getCategoriaId())
+                .orElseThrow(() -> new RuntimeException("Categoría no encontrada"));
+        Producto p = new Producto();
+        p.setNombre(dto.getNombre());
+        p.setDescripcion(dto.getDescripcion());
+        p.setPrecio(dto.getPrecio());
+        p.setStock(dto.getStock());
+        p.setCategoria(categoria);
+        return productoRepository.save(p);
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/producto/DeleteProductoUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/producto/DeleteProductoUseCase.java
@@ -1,0 +1,22 @@
+package com.proyecto.erpventas.application.usecases.producto;
+
+import com.proyecto.erpventas.domain.model.inventory.Producto;
+import com.proyecto.erpventas.infrastructure.repository.producto.ProductoRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DeleteProductoUseCase {
+
+    private final ProductoRepository productoRepository;
+
+    public DeleteProductoUseCase(ProductoRepository productoRepository) {
+        this.productoRepository = productoRepository;
+    }
+
+    public void delete(Integer id) {
+        Producto existing = productoRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Producto no encontrado"));
+        existing.setActivo(false);
+        productoRepository.save(existing);
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/producto/GetProductoByIdUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/producto/GetProductoByIdUseCase.java
@@ -1,0 +1,21 @@
+package com.proyecto.erpventas.application.usecases.producto;
+
+import com.proyecto.erpventas.domain.model.inventory.Producto;
+import com.proyecto.erpventas.infrastructure.repository.producto.ProductoRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class GetProductoByIdUseCase {
+
+    private final ProductoRepository productoRepository;
+
+    public GetProductoByIdUseCase(ProductoRepository productoRepository) {
+        this.productoRepository = productoRepository;
+    }
+
+    public Optional<Producto> getById(Integer id) {
+        return productoRepository.findById(id);
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/producto/ListProductosUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/producto/ListProductosUseCase.java
@@ -1,0 +1,21 @@
+package com.proyecto.erpventas.application.usecases.producto;
+
+import com.proyecto.erpventas.domain.model.inventory.Producto;
+import com.proyecto.erpventas.infrastructure.repository.producto.ProductoRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ListProductosUseCase {
+
+    private final ProductoRepository productoRepository;
+
+    public ListProductosUseCase(ProductoRepository productoRepository) {
+        this.productoRepository = productoRepository;
+    }
+
+    public List<Producto> listAll() {
+        return productoRepository.findAllByActivoTrue();
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/producto/UpdateProductoUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/producto/UpdateProductoUseCase.java
@@ -1,0 +1,34 @@
+package com.proyecto.erpventas.application.usecases.producto;
+
+import com.proyecto.erpventas.application.dto.request.producto.UpdateProductoDTO;
+import com.proyecto.erpventas.domain.model.inventory.CategoriaProducto;
+import com.proyecto.erpventas.domain.model.inventory.Producto;
+import com.proyecto.erpventas.infrastructure.repository.categoria.CategoriaProductoRepository;
+import com.proyecto.erpventas.infrastructure.repository.producto.ProductoRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UpdateProductoUseCase {
+
+    private final ProductoRepository productoRepository;
+    private final CategoriaProductoRepository categoriaRepository;
+
+    public UpdateProductoUseCase(ProductoRepository productoRepository,
+                                 CategoriaProductoRepository categoriaRepository) {
+        this.productoRepository = productoRepository;
+        this.categoriaRepository = categoriaRepository;
+    }
+
+    public Producto update(Integer id, UpdateProductoDTO dto) {
+        Producto existing = productoRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Producto no encontrado"));
+        CategoriaProducto categoria = categoriaRepository.findById(dto.getCategoriaId())
+                .orElseThrow(() -> new RuntimeException("Categoría no encontrada"));
+        existing.setNombre(dto.getNombre());
+        existing.setDescripcion(dto.getDescripcion());
+        existing.setPrecio(dto.getPrecio());
+        existing.setStock(dto.getStock());
+        existing.setCategoria(categoria);
+        return productoRepository.save(existing);
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/domain/model/inventory/CategoriaProducto.java
+++ b/backend/src/main/java/com/proyecto/erpventas/domain/model/inventory/CategoriaProducto.java
@@ -1,5 +1,26 @@
 package com.proyecto.erpventas.domain.model.inventory;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "CategoriasProducto")
+@Getter
+@Setter
 public class CategoriaProducto {
-    
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "categoriaid")
+    private Integer categoriaId;
+
+    @Column(name = "nombre", nullable = false, unique = true)
+    private String nombre;
+
+    @Column(name = "descripcion")
+    private String descripcion;
+
+    @Column(name = "activo", nullable = false)
+    private Boolean activo = true;
 }

--- a/backend/src/main/java/com/proyecto/erpventas/domain/model/inventory/Producto.java
+++ b/backend/src/main/java/com/proyecto/erpventas/domain/model/inventory/Producto.java
@@ -5,6 +5,12 @@ import lombok.Getter;
 import lombok.Setter;
 import java.math.BigDecimal;
 
+/**
+ * Producto disponible para la venta.
+ */
+
+import com.proyecto.erpventas.domain.model.inventory.CategoriaProducto;
+
 @Entity
 @Table(name = "Productos")
 @Getter
@@ -27,6 +33,10 @@ public class Producto {
 
     @Column(name = "stock", nullable = false)
     private Integer stock;
+
+    @ManyToOne
+    @JoinColumn(name = "categoriaid", nullable = false)
+    private CategoriaProducto categoria;
 
     @Column(name = "activo", nullable = false)
     private Boolean activo = true;

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/controller/CategoriaProductoController.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/controller/CategoriaProductoController.java
@@ -1,0 +1,80 @@
+package com.proyecto.erpventas.infrastructure.controller;
+
+import com.proyecto.erpventas.application.dto.request.categoria.CreateCategoriaDTO;
+import com.proyecto.erpventas.application.dto.request.categoria.UpdateCategoriaDTO;
+import com.proyecto.erpventas.application.dto.response.categoria.CategoriaResponseDTO;
+import com.proyecto.erpventas.application.usecases.categoria.*;
+import com.proyecto.erpventas.domain.model.inventory.CategoriaProducto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/categorias-producto")
+public class CategoriaProductoController {
+
+    private final CreateCategoriaUseCase createUC;
+    private final ListCategoriasUseCase listUC;
+    private final GetCategoriaByIdUseCase getByIdUC;
+    private final UpdateCategoriaUseCase updateUC;
+    private final DeleteCategoriaUseCase deleteUC;
+
+    public CategoriaProductoController(CreateCategoriaUseCase createUC,
+                                       ListCategoriasUseCase listUC,
+                                       GetCategoriaByIdUseCase getByIdUC,
+                                       UpdateCategoriaUseCase updateUC,
+                                       DeleteCategoriaUseCase deleteUC) {
+        this.createUC = createUC;
+        this.listUC = listUC;
+        this.getByIdUC = getByIdUC;
+        this.updateUC = updateUC;
+        this.deleteUC = deleteUC;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CategoriaResponseDTO>> getAll() {
+        List<CategoriaProducto> categorias = listUC.listAll();
+        List<CategoriaResponseDTO> dto = categorias.stream()
+                .map(c -> new CategoriaResponseDTO(
+                        c.getCategoriaId(),
+                        c.getNombre(),
+                        c.getDescripcion(),
+                        c.getActivo()
+                )).toList();
+        return ResponseEntity.ok(dto);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<CategoriaResponseDTO> getById(@PathVariable Integer id) {
+        CategoriaProducto c = getByIdUC.getById(id)
+                .orElseThrow(() -> new RuntimeException("Categoría no encontrada"));
+        CategoriaResponseDTO dto = new CategoriaResponseDTO(
+                c.getCategoriaId(), c.getNombre(), c.getDescripcion(), c.getActivo());
+        return ResponseEntity.ok(dto);
+    }
+
+    @PostMapping
+    public ResponseEntity<CategoriaResponseDTO> create(@Valid @RequestBody CreateCategoriaDTO dto) {
+        CategoriaProducto created = createUC.create(dto);
+        CategoriaResponseDTO resp = new CategoriaResponseDTO(
+                created.getCategoriaId(), created.getNombre(), created.getDescripcion(), created.getActivo());
+        return ResponseEntity.ok(resp);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<CategoriaResponseDTO> update(@PathVariable Integer id,
+                                                       @Valid @RequestBody UpdateCategoriaDTO dto) {
+        CategoriaProducto updated = updateUC.update(id, dto);
+        CategoriaResponseDTO resp = new CategoriaResponseDTO(
+                updated.getCategoriaId(), updated.getNombre(), updated.getDescripcion(), updated.getActivo());
+        return ResponseEntity.ok(resp);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> delete(@PathVariable Integer id) {
+        deleteUC.delete(id);
+        return ResponseEntity.ok("Categoría eliminada correctamente (borrado lógico)");
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/controller/ProductoController.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/controller/ProductoController.java
@@ -1,0 +1,83 @@
+package com.proyecto.erpventas.infrastructure.controller;
+
+import com.proyecto.erpventas.application.dto.request.producto.CreateProductoDTO;
+import com.proyecto.erpventas.application.dto.request.producto.UpdateProductoDTO;
+import com.proyecto.erpventas.application.dto.response.producto.ProductoResponseDTO;
+import com.proyecto.erpventas.application.usecases.producto.*;
+import com.proyecto.erpventas.domain.model.inventory.Producto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/productos")
+public class ProductoController {
+
+    private final CreateProductoUseCase createUC;
+    private final ListProductosUseCase listUC;
+    private final GetProductoByIdUseCase getByIdUC;
+    private final UpdateProductoUseCase updateUC;
+    private final DeleteProductoUseCase deleteUC;
+
+    public ProductoController(CreateProductoUseCase createUC,
+                              ListProductosUseCase listUC,
+                              GetProductoByIdUseCase getByIdUC,
+                              UpdateProductoUseCase updateUC,
+                              DeleteProductoUseCase deleteUC) {
+        this.createUC = createUC;
+        this.listUC = listUC;
+        this.getByIdUC = getByIdUC;
+        this.updateUC = updateUC;
+        this.deleteUC = deleteUC;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ProductoResponseDTO>> getAll() {
+        List<Producto> productos = listUC.listAll();
+        List<ProductoResponseDTO> dto = productos.stream()
+                .map(this::toDto)
+                .toList();
+        return ResponseEntity.ok(dto);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ProductoResponseDTO> getById(@PathVariable Integer id) {
+        Producto p = getByIdUC.getById(id)
+                .orElseThrow(() -> new RuntimeException("Producto no encontrado"));
+        return ResponseEntity.ok(toDto(p));
+    }
+
+    @PostMapping
+    public ResponseEntity<ProductoResponseDTO> create(@Valid @RequestBody CreateProductoDTO dto) {
+        Producto created = createUC.create(dto);
+        return ResponseEntity.ok(toDto(created));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ProductoResponseDTO> update(@PathVariable Integer id,
+                                                      @Valid @RequestBody UpdateProductoDTO dto) {
+        Producto updated = updateUC.update(id, dto);
+        return ResponseEntity.ok(toDto(updated));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> delete(@PathVariable Integer id) {
+        deleteUC.delete(id);
+        return ResponseEntity.ok("Producto eliminado correctamente (borrado lógico)");
+    }
+
+    private ProductoResponseDTO toDto(Producto p) {
+        return new ProductoResponseDTO(
+                p.getProductoId(),
+                p.getNombre(),
+                p.getDescripcion(),
+                p.getPrecio(),
+                p.getStock(),
+                p.getCategoria().getCategoriaId(),
+                p.getCategoria().getNombre(),
+                p.getActivo()
+        );
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/categoria/CategoriaProductoRepository.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/categoria/CategoriaProductoRepository.java
@@ -1,0 +1,18 @@
+package com.proyecto.erpventas.infrastructure.repository.categoria;
+
+import com.proyecto.erpventas.domain.model.inventory.CategoriaProducto;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CategoriaProductoRepository {
+    boolean existsByNombre(String nombre);
+    Optional<CategoriaProducto> findByNombre(String nombre);
+    CategoriaProducto save(CategoriaProducto categoria);
+    CategoriaProducto saveAndFlush(CategoriaProducto categoria);
+    Optional<CategoriaProducto> findById(Integer id);
+    List<CategoriaProducto> findAll();
+    List<CategoriaProducto> findAllByActivoTrue();
+    void deleteById(Integer id); // borrado lógico
+    void softDeleteById(Integer id);
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/categoria/CategoriaProductoRepositoryImpl.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/categoria/CategoriaProductoRepositoryImpl.java
@@ -1,0 +1,69 @@
+package com.proyecto.erpventas.infrastructure.repository.categoria;
+
+import com.proyecto.erpventas.domain.model.inventory.CategoriaProducto;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class CategoriaProductoRepositoryImpl implements CategoriaProductoRepository {
+
+    private final SpringCategoriaProductoJpaRepository jpaRepository;
+
+    public CategoriaProductoRepositoryImpl(SpringCategoriaProductoJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public boolean existsByNombre(String nombre) {
+        return jpaRepository.existsByNombre(nombre);
+    }
+
+    @Override
+    public Optional<CategoriaProducto> findByNombre(String nombre) {
+        return jpaRepository.findByNombre(nombre).filter(CategoriaProducto::getActivo);
+    }
+
+    @Override
+    public CategoriaProducto save(CategoriaProducto categoria) {
+        return jpaRepository.save(categoria);
+    }
+
+    @Override
+    public CategoriaProducto saveAndFlush(CategoriaProducto categoria) {
+        return jpaRepository.saveAndFlush(categoria);
+    }
+
+    @Override
+    public Optional<CategoriaProducto> findById(Integer id) {
+        return jpaRepository.findById(id.longValue()).filter(CategoriaProducto::getActivo);
+    }
+
+    @Override
+    public List<CategoriaProducto> findAll() {
+        return jpaRepository.findAllByActivoTrueOrderByNombreAsc();
+    }
+
+    @Override
+    public List<CategoriaProducto> findAllByActivoTrue() {
+        return findAll();
+    }
+
+    @Override
+    public void softDeleteById(Integer id) {
+        Optional<CategoriaProducto> opt = jpaRepository.findById(id.longValue());
+        if (opt.isPresent()) {
+            CategoriaProducto c = opt.get();
+            c.setActivo(false);
+            jpaRepository.save(c);
+        } else {
+            throw new RuntimeException("Categoría no encontrada");
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        softDeleteById(id);
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/categoria/SpringCategoriaProductoJpaRepository.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/categoria/SpringCategoriaProductoJpaRepository.java
@@ -1,0 +1,13 @@
+package com.proyecto.erpventas.infrastructure.repository.categoria;
+
+import com.proyecto.erpventas.domain.model.inventory.CategoriaProducto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SpringCategoriaProductoJpaRepository extends JpaRepository<CategoriaProducto, Long> {
+    boolean existsByNombre(String nombre);
+    Optional<CategoriaProducto> findByNombre(String nombre);
+    List<CategoriaProducto> findAllByActivoTrueOrderByNombreAsc();
+}


### PR DESCRIPTION
## Summary
- create DTOs for categorias and update producto DTOs with categoria
- add domain entity mapping for CategoriaProducto and relation in Producto
- implement repositories and use cases for CategoriaProducto and Producto
- expose REST controllers for categorias-producto and productos

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684aafd844c883248c98ea27ca88c69d