### PR TITLE
Add product and category interfaces

### DIFF
--- a/frontend/src/app/core/models/productos/categoria-producto.model.ts
+++ b/frontend/src/app/core/models/productos/categoria-producto.model.ts
@@ -1,0 +1,6 @@
+export interface CategoriaProducto {
+  categoriaId: number;
+  nombre: string;
+  descripcion: string;
+  activo: boolean;
+}

--- a/frontend/src/app/core/models/productos/producto.model.ts
+++ b/frontend/src/app/core/models/productos/producto.model.ts
@@ -1,0 +1,10 @@
+export interface Producto {
+  productoId: number;
+  nombre: string;
+  descripcion: string;
+  precio: number;
+  stock: number;
+  categoriaId: number;
+  categoriaNombre: string;
+  activo: boolean;
+}


### PR DESCRIPTION
## Summary
- define `Producto` model with fields matching backend DTO
- define `CategoriaProducto` model

## Testing
- `npx prettier -w frontend/src/app/core/models/productos/producto.model.ts frontend/src/app/core/models/productos/categoria-producto.model.ts`

------
https://chatgpt.com/codex/tasks/task_e_684aafdaeac0832492c00ca71682a7eb