### PR TITLE
Add product and category management pages

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -41,6 +41,20 @@ export const routes: Routes = [
           import('./features/ventas/pages/ventas.component').then((m) => m.VentasComponent),
       },
       {
+        path: 'productos',
+        loadComponent: () =>
+          import('./features/productos/pages/productos.component').then(
+            (m) => m.ProductosComponent,
+          ),
+      },
+      {
+        path: 'categorias',
+        loadComponent: () =>
+          import('./features/categorias/pages/categorias.component').then(
+            (m) => m.CategoriasComponent,
+          ),
+      },
+      {
         path: 'reporte-ventas',
         loadComponent: () =>
           import('./features/reportes/pages/reporte-ventas/reporte-ventas.component').then(

--- a/frontend/src/app/core/models/productos/categoria-producto.model.ts
+++ b/frontend/src/app/core/models/productos/categoria-producto.model.ts
@@ -1,0 +1,6 @@
+export interface CategoriaProducto {
+  categoriaId: number;
+  nombre: string;
+  descripcion?: string;
+  activo: boolean;
+}

--- a/frontend/src/app/core/models/productos/create-categoria-dto.model.ts
+++ b/frontend/src/app/core/models/productos/create-categoria-dto.model.ts
@@ -1,0 +1,4 @@
+export interface CreateCategoriaDTO {
+  nombre: string;
+  descripcion?: string;
+}

--- a/frontend/src/app/core/models/productos/create-producto-dto.model.ts
+++ b/frontend/src/app/core/models/productos/create-producto-dto.model.ts
@@ -1,8 +1,6 @@
-export interface Producto {
-  productoId: number;
+export interface CreateProductoDTO {
   nombre: string;
   descripcion?: string;
   precio: number;
   stock: number;
-  activo: boolean;
 }

--- a/frontend/src/app/core/models/productos/update-categoria-dto.model.ts
+++ b/frontend/src/app/core/models/productos/update-categoria-dto.model.ts
@@ -1,0 +1,4 @@
+export interface UpdateCategoriaDTO {
+  nombre: string;
+  descripcion?: string;
+}

--- a/frontend/src/app/core/models/productos/update-producto-dto.model.ts
+++ b/frontend/src/app/core/models/productos/update-producto-dto.model.ts
@@ -1,8 +1,6 @@
-export interface Producto {
-  productoId: number;
+export interface UpdateProductoDTO {
   nombre: string;
   descripcion?: string;
   precio: number;
   stock: number;
-  activo: boolean;
 }

--- a/frontend/src/app/features/categorias/pages/categorias-create-edit-dialog.component.html
+++ b/frontend/src/app/features/categorias/pages/categorias-create-edit-dialog.component.html
@@ -1,0 +1,22 @@
+<h2 mat-dialog-title>
+  {{ isEdit ? 'Editar Categoría #' + (data.categoria?.categoriaId ?? '') : 'Nueva Categoría' }}
+</h2>
+
+<form [formGroup]="form" (ngSubmit)="submit()" mat-dialog-content>
+  <mat-form-field appearance="outline" class="w-100 mb-3">
+    <mat-label>Nombre</mat-label>
+    <input matInput formControlName="nombre" />
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="w-100 mb-3">
+    <mat-label>Descripción</mat-label>
+    <textarea matInput formControlName="descripcion"></textarea>
+  </mat-form-field>
+</form>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancelar()">Cancelar</button>
+  <button mat-flat-button color="primary" [disabled]="form.invalid" (click)="submit()">
+    {{ isEdit ? 'Actualizar' : 'Crear' }}
+  </button>
+</mat-dialog-actions>

--- a/frontend/src/app/features/categorias/pages/categorias-create-edit-dialog.component.scss
+++ b/frontend/src/app/features/categorias/pages/categorias-create-edit-dialog.component.scss
@@ -1,0 +1,1 @@
+/* Estilos básicos para el diálogo */

--- a/frontend/src/app/features/categorias/pages/categorias-create-edit-dialog.component.ts
+++ b/frontend/src/app/features/categorias/pages/categorias-create-edit-dialog.component.ts
@@ -1,0 +1,83 @@
+import { Component, Inject, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+
+import { CategoriaProducto } from 'src/app/core/models/productos/categoria-producto.model';
+import { CategoriasApiService } from 'src/app/infrastructure/api/categorias/categorias-api.service';
+import { CreateCategoriaDTO } from 'src/app/core/models/productos/create-categoria-dto.model';
+import { UpdateCategoriaDTO } from 'src/app/core/models/productos/update-categoria-dto.model';
+
+@Component({
+  selector: 'app-categorias-create-edit-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatSnackBarModule,
+  ],
+  templateUrl: './categorias-create-edit-dialog.component.html',
+  styleUrls: ['./categorias-create-edit-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CategoriasCreateEditDialogComponent implements OnInit {
+  form!: FormGroup;
+  isEdit: boolean;
+
+  constructor(
+    private fb: FormBuilder,
+    private api: CategoriasApiService,
+    private snackBar: MatSnackBar,
+    @Inject(MAT_DIALOG_DATA) public data: { categoria?: CategoriaProducto },
+    private dialogRef: MatDialogRef<CategoriasCreateEditDialogComponent>,
+  ) {
+    this.isEdit = !!data.categoria;
+  }
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      nombre: [this.data.categoria?.nombre ?? '', Validators.required],
+      descripcion: [this.data.categoria?.descripcion ?? ''],
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid) return;
+
+    if (this.isEdit && this.data.categoria) {
+      const dto: UpdateCategoriaDTO = this.form.value;
+      this.api.actualizarCategoria(this.data.categoria.categoriaId, dto).subscribe({
+        next: () => {
+          this.snackBar.open('Categoría actualizada correctamente', '', { duration: 3000 });
+          this.dialogRef.close(true);
+        },
+        error: (err: Error) => {
+          this.snackBar.open(`Error: ${err.message}`, '', { duration: 5000 });
+        },
+      });
+    } else {
+      const dto: CreateCategoriaDTO = this.form.value;
+      this.api.crearCategoria(dto).subscribe({
+        next: () => {
+          this.snackBar.open('Categoría creada correctamente', '', { duration: 3000 });
+          this.dialogRef.close(true);
+        },
+        error: (err: Error) => {
+          this.snackBar.open(`Error: ${err.message}`, '', { duration: 5000 });
+        },
+      });
+    }
+  }
+
+  cancelar(): void {
+    this.dialogRef.close();
+  }
+}

--- a/frontend/src/app/features/categorias/pages/categorias.component.html
+++ b/frontend/src/app/features/categorias/pages/categorias.component.html
@@ -1,0 +1,48 @@
+<div class="row mb-3">
+  <mat-form-field class="col-12 col-md-6 form-field-full" appearance="outline">
+    <mat-label>Buscar categoría</mat-label>
+    <input #searchInput matInput (keyup)="filtrarCategoria($event)" placeholder="Nombre" />
+    <button *ngIf="dataSource.filter" matSuffix mat-icon-button aria-label="Limpiar búsqueda" (click)="clearFilter()">
+      <mat-icon>close</mat-icon>
+    </button>
+  </mat-form-field>
+</div>
+
+<mat-card>
+  <mat-card-header>
+    <mat-card-title>Listado de Categorías</mat-card-title>
+    <button mat-fab color="primary" class="fab-add" (click)="nuevaCategoria()" aria-label="Nueva Categoría">
+      <mat-icon>add</mat-icon>
+    </button>
+  </mat-card-header>
+
+  <mat-card-content class="table-container">
+    <div *ngIf="loading" class="spinner-container">
+      <mat-spinner></mat-spinner>
+    </div>
+
+    <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z1">
+      <ng-container matColumnDef="nombre">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Nombre</th>
+        <td mat-cell *matCellDef="let c">{{ c.nombre }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="acciones">
+        <th mat-header-cell *matHeaderCellDef>Acciones</th>
+        <td mat-cell *matCellDef="let c">
+          <button mat-icon-button color="primary" (click)="editarCategoria(c)" aria-label="Editar">
+            <mat-icon>edit</mat-icon>
+          </button>
+          <button mat-icon-button color="warn" (click)="eliminarCategoria(c.categoriaId)" aria-label="Eliminar">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+
+    <mat-paginator [pageSizeOptions]="[10, 25, 50]" showFirstLastButtons></mat-paginator>
+  </mat-card-content>
+</mat-card>

--- a/frontend/src/app/features/categorias/pages/categorias.component.scss
+++ b/frontend/src/app/features/categorias/pages/categorias.component.scss
@@ -1,0 +1,13 @@
+.table-container {
+  position: relative;
+}
+.spinner-container {
+  display: flex;
+  justify-content: center;
+  margin: 20px 0;
+}
+.fab-add {
+  position: absolute;
+  top: -28px;
+  right: 16px;
+}

--- a/frontend/src/app/features/categorias/pages/categorias.component.ts
+++ b/frontend/src/app/features/categorias/pages/categorias.component.ts
@@ -1,0 +1,116 @@
+import { Component, OnInit, ChangeDetectionStrategy, ViewChild, ElementRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
+import { MatPaginatorModule, MatPaginator } from '@angular/material/paginator';
+import { MatSortModule, MatSort } from '@angular/material/sort';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatCardModule } from '@angular/material/card';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+import { CategoriaProducto } from 'src/app/core/models/productos/categoria-producto.model';
+import { CategoriasApiService } from 'src/app/infrastructure/api/categorias/categorias-api.service';
+import { CategoriasCreateEditDialogComponent } from './categorias-create-edit-dialog.component';
+
+@Component({
+  selector: 'app-categorias',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatSortModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDialogModule,
+    MatSnackBarModule,
+    MatCardModule,
+    MatProgressSpinnerModule,
+  ],
+  templateUrl: './categorias.component.html',
+  styleUrls: ['./categorias.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CategoriasComponent implements OnInit {
+  dataSource = new MatTableDataSource<CategoriaProducto>();
+  loading = false;
+  displayedColumns = ['nombre', 'acciones'];
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+  @ViewChild('searchInput') searchInput!: ElementRef<HTMLInputElement>;
+
+  constructor(
+    private api: CategoriasApiService,
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar,
+  ) {}
+
+  ngOnInit(): void {
+    this.cargarCategorias();
+  }
+
+  private cargarCategorias(): void {
+    this.loading = true;
+    this.api.obtenerCategorias().subscribe({
+      next: (data: CategoriaProducto[]) => {
+        this.dataSource.data = data.filter((c) => c.activo);
+        this.dataSource.paginator = this.paginator;
+        this.dataSource.sort = this.sort;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+        this.snackBar.open('Error al cargar categorías', '', { duration: 3000 });
+      },
+    });
+  }
+
+  filtrarCategoria(event: Event): void {
+    const filtro = (event.target as HTMLInputElement).value.trim().toLowerCase();
+    this.dataSource.filter = filtro;
+  }
+
+  clearFilter(): void {
+    this.dataSource.filter = '';
+    this.searchInput.nativeElement.value = '';
+  }
+
+  nuevaCategoria(): void {
+    const ref = this.dialog.open(CategoriasCreateEditDialogComponent, {
+      width: '500px',
+      data: {},
+    });
+    ref.afterClosed().subscribe((created: boolean) => {
+      if (created) this.cargarCategorias();
+    });
+  }
+
+  editarCategoria(categoria: CategoriaProducto): void {
+    const ref = this.dialog.open(CategoriasCreateEditDialogComponent, {
+      width: '500px',
+      data: { categoria },
+    });
+    ref.afterClosed().subscribe((updated: boolean) => {
+      if (updated) this.cargarCategorias();
+    });
+  }
+
+  eliminarCategoria(id: number): void {
+    this.api.eliminarCategoria(id).subscribe({
+      next: () => {
+        this.snackBar.open('Categoría eliminada correctamente', '', { duration: 3000 });
+        this.cargarCategorias();
+      },
+      error: (err: Error) => {
+        this.snackBar.open(`Error: ${err.message}`, '', { duration: 5000 });
+      },
+    });
+  }
+}

--- a/frontend/src/app/features/productos/pages/productos-create-edit-dialog.component.html
+++ b/frontend/src/app/features/productos/pages/productos-create-edit-dialog.component.html
@@ -1,0 +1,32 @@
+<h2 mat-dialog-title>
+  {{ isEdit ? 'Editar Producto #' + (data.producto?.productoId ?? '') : 'Nuevo Producto' }}
+</h2>
+
+<form [formGroup]="form" (ngSubmit)="submit()" mat-dialog-content>
+  <mat-form-field appearance="outline" class="w-100 mb-3">
+    <mat-label>Nombre</mat-label>
+    <input matInput formControlName="nombre" />
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="w-100 mb-3">
+    <mat-label>Descripción</mat-label>
+    <textarea matInput formControlName="descripcion"></textarea>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="w-100 mb-3">
+    <mat-label>Precio (Bs)</mat-label>
+    <input matInput type="number" formControlName="precio" />
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="w-100 mb-3">
+    <mat-label>Stock</mat-label>
+    <input matInput type="number" formControlName="stock" />
+  </mat-form-field>
+</form>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancelar()">Cancelar</button>
+  <button mat-flat-button color="primary" [disabled]="form.invalid" (click)="submit()">
+    {{ isEdit ? 'Actualizar' : 'Crear' }}
+  </button>
+</mat-dialog-actions>

--- a/frontend/src/app/features/productos/pages/productos-create-edit-dialog.component.scss
+++ b/frontend/src/app/features/productos/pages/productos-create-edit-dialog.component.scss
@@ -1,0 +1,1 @@
+/* Estilos básicos para el diálogo */

--- a/frontend/src/app/features/productos/pages/productos-create-edit-dialog.component.ts
+++ b/frontend/src/app/features/productos/pages/productos-create-edit-dialog.component.ts
@@ -1,0 +1,85 @@
+import { Component, Inject, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+
+import { Producto } from 'src/app/core/models/productos/producto.model';
+import { ProductosApiService } from 'src/app/infrastructure/api/productos/productos-api.service';
+import { CreateProductoDTO } from 'src/app/core/models/productos/create-producto-dto.model';
+import { UpdateProductoDTO } from 'src/app/core/models/productos/update-producto-dto.model';
+
+@Component({
+  selector: 'app-productos-create-edit-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatSnackBarModule,
+  ],
+  templateUrl: './productos-create-edit-dialog.component.html',
+  styleUrls: ['./productos-create-edit-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProductosCreateEditDialogComponent implements OnInit {
+  form!: FormGroup;
+  isEdit: boolean;
+
+  constructor(
+    private fb: FormBuilder,
+    private api: ProductosApiService,
+    private snackBar: MatSnackBar,
+    @Inject(MAT_DIALOG_DATA) public data: { producto?: Producto },
+    private dialogRef: MatDialogRef<ProductosCreateEditDialogComponent>,
+  ) {
+    this.isEdit = !!data.producto;
+  }
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      nombre: [this.data.producto?.nombre ?? '', Validators.required],
+      descripcion: [this.data.producto?.descripcion ?? ''],
+      precio: [this.data.producto?.precio ?? '', [Validators.required, Validators.min(0)]],
+      stock: [this.data.producto?.stock ?? '', [Validators.required, Validators.min(0)]],
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid) return;
+
+    if (this.isEdit && this.data.producto) {
+      const dto: UpdateProductoDTO = this.form.value;
+      this.api.actualizarProducto(this.data.producto.productoId, dto).subscribe({
+        next: () => {
+          this.snackBar.open('Producto actualizado correctamente', '', { duration: 3000 });
+          this.dialogRef.close(true);
+        },
+        error: (err: Error) => {
+          this.snackBar.open(`Error: ${err.message}`, '', { duration: 5000 });
+        },
+      });
+    } else {
+      const dto: CreateProductoDTO = this.form.value;
+      this.api.crearProducto(dto).subscribe({
+        next: () => {
+          this.snackBar.open('Producto creado correctamente', '', { duration: 3000 });
+          this.dialogRef.close(true);
+        },
+        error: (err: Error) => {
+          this.snackBar.open(`Error: ${err.message}`, '', { duration: 5000 });
+        },
+      });
+    }
+  }
+
+  cancelar(): void {
+    this.dialogRef.close();
+  }
+}

--- a/frontend/src/app/features/productos/pages/productos.component.html
+++ b/frontend/src/app/features/productos/pages/productos.component.html
@@ -1,0 +1,58 @@
+<div class="row mb-3">
+  <mat-form-field class="col-12 col-md-6 form-field-full" appearance="outline">
+    <mat-label>Buscar producto</mat-label>
+    <input #searchInput matInput (keyup)="filtrarProducto($event)" placeholder="Nombre" />
+    <button *ngIf="dataSource.filter" matSuffix mat-icon-button aria-label="Limpiar búsqueda" (click)="clearFilter()">
+      <mat-icon>close</mat-icon>
+    </button>
+  </mat-form-field>
+</div>
+
+<mat-card>
+  <mat-card-header>
+    <mat-card-title>Listado de Productos</mat-card-title>
+    <button mat-fab color="primary" class="fab-add" (click)="nuevoProducto()" aria-label="Nuevo Producto">
+      <mat-icon>add</mat-icon>
+    </button>
+  </mat-card-header>
+
+  <mat-card-content class="table-container">
+    <div *ngIf="loading" class="spinner-container">
+      <mat-spinner></mat-spinner>
+    </div>
+
+    <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z1">
+      <ng-container matColumnDef="nombre">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Nombre</th>
+        <td mat-cell *matCellDef="let p">{{ p.nombre }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="precio">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Precio (Bs)</th>
+        <td mat-cell *matCellDef="let p">{{ p.precio | number: '1.2-2' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="stock">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Stock</th>
+        <td mat-cell *matCellDef="let p">{{ p.stock }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="acciones">
+        <th mat-header-cell *matHeaderCellDef>Acciones</th>
+        <td mat-cell *matCellDef="let p">
+          <button mat-icon-button color="primary" (click)="editarProducto(p)" aria-label="Editar">
+            <mat-icon>edit</mat-icon>
+          </button>
+          <button mat-icon-button color="warn" (click)="eliminarProducto(p.productoId)" aria-label="Eliminar">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+
+    <mat-paginator [pageSizeOptions]="[10, 25, 50]" showFirstLastButtons></mat-paginator>
+  </mat-card-content>
+</mat-card>

--- a/frontend/src/app/features/productos/pages/productos.component.scss
+++ b/frontend/src/app/features/productos/pages/productos.component.scss
@@ -1,0 +1,13 @@
+.table-container {
+  position: relative;
+}
+.spinner-container {
+  display: flex;
+  justify-content: center;
+  margin: 20px 0;
+}
+.fab-add {
+  position: absolute;
+  top: -28px;
+  right: 16px;
+}

--- a/frontend/src/app/features/productos/pages/productos.component.ts
+++ b/frontend/src/app/features/productos/pages/productos.component.ts
@@ -1,0 +1,116 @@
+import { Component, OnInit, ChangeDetectionStrategy, ViewChild, ElementRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
+import { MatPaginatorModule, MatPaginator } from '@angular/material/paginator';
+import { MatSortModule, MatSort } from '@angular/material/sort';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatCardModule } from '@angular/material/card';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+import { Producto } from 'src/app/core/models/productos/producto.model';
+import { ProductosApiService } from 'src/app/infrastructure/api/productos/productos-api.service';
+import { ProductosCreateEditDialogComponent } from './productos-create-edit-dialog.component';
+
+@Component({
+  selector: 'app-productos',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatSortModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDialogModule,
+    MatSnackBarModule,
+    MatCardModule,
+    MatProgressSpinnerModule,
+  ],
+  templateUrl: './productos.component.html',
+  styleUrls: ['./productos.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProductosComponent implements OnInit {
+  dataSource = new MatTableDataSource<Producto>();
+  loading = false;
+  displayedColumns = ['nombre', 'precio', 'stock', 'acciones'];
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+  @ViewChild('searchInput') searchInput!: ElementRef<HTMLInputElement>;
+
+  constructor(
+    private api: ProductosApiService,
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar,
+  ) {}
+
+  ngOnInit(): void {
+    this.cargarProductos();
+  }
+
+  private cargarProductos(): void {
+    this.loading = true;
+    this.api.obtenerProductos().subscribe({
+      next: (data: Producto[]) => {
+        this.dataSource.data = data.filter((p) => p.activo);
+        this.dataSource.paginator = this.paginator;
+        this.dataSource.sort = this.sort;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+        this.snackBar.open('Error al cargar productos', '', { duration: 3000 });
+      },
+    });
+  }
+
+  filtrarProducto(event: Event): void {
+    const filtro = (event.target as HTMLInputElement).value.trim().toLowerCase();
+    this.dataSource.filter = filtro;
+  }
+
+  clearFilter(): void {
+    this.dataSource.filter = '';
+    this.searchInput.nativeElement.value = '';
+  }
+
+  nuevoProducto(): void {
+    const ref = this.dialog.open(ProductosCreateEditDialogComponent, {
+      width: '500px',
+      data: {},
+    });
+    ref.afterClosed().subscribe((created: boolean) => {
+      if (created) this.cargarProductos();
+    });
+  }
+
+  editarProducto(producto: Producto): void {
+    const ref = this.dialog.open(ProductosCreateEditDialogComponent, {
+      width: '500px',
+      data: { producto },
+    });
+    ref.afterClosed().subscribe((updated: boolean) => {
+      if (updated) this.cargarProductos();
+    });
+  }
+
+  eliminarProducto(id: number): void {
+    this.api.eliminarProducto(id).subscribe({
+      next: () => {
+        this.snackBar.open('Producto eliminado correctamente', '', { duration: 3000 });
+        this.cargarProductos();
+      },
+      error: (err: Error) => {
+        this.snackBar.open(`Error: ${err.message}`, '', { duration: 5000 });
+      },
+    });
+  }
+}

--- a/frontend/src/app/infrastructure/api/categorias/categorias-api.service.ts
+++ b/frontend/src/app/infrastructure/api/categorias/categorias-api.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { CategoriaProducto } from 'src/app/core/models/productos/categoria-producto.model';
+import { CreateCategoriaDTO } from 'src/app/core/models/productos/create-categoria-dto.model';
+import { UpdateCategoriaDTO } from 'src/app/core/models/productos/update-categoria-dto.model';
+
+@Injectable({ providedIn: 'root' })
+export class CategoriasApiService {
+  private baseUrl = '/api/categorias';
+
+  constructor(private http: HttpClient) {}
+
+  obtenerCategorias(): Observable<CategoriaProducto[]> {
+    return this.http.get<CategoriaProducto[]>(this.baseUrl);
+  }
+
+  crearCategoria(dto: CreateCategoriaDTO): Observable<CategoriaProducto> {
+    return this.http.post<CategoriaProducto>(this.baseUrl, dto);
+  }
+
+  actualizarCategoria(id: number, dto: UpdateCategoriaDTO): Observable<CategoriaProducto> {
+    return this.http.put<CategoriaProducto>(`${this.baseUrl}/${id}`, dto);
+  }
+
+  eliminarCategoria(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+}

--- a/frontend/src/app/infrastructure/api/productos/productos-api.service.ts
+++ b/frontend/src/app/infrastructure/api/productos/productos-api.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Producto } from 'src/app/core/models/productos/producto.model';
+import { CreateProductoDTO } from 'src/app/core/models/productos/create-producto-dto.model';
+import { UpdateProductoDTO } from 'src/app/core/models/productos/update-producto-dto.model';
+
+@Injectable({ providedIn: 'root' })
+export class ProductosApiService {
+  private baseUrl = '/api/productos';
+
+  constructor(private http: HttpClient) {}
+
+  obtenerProductos(): Observable<Producto[]> {
+    return this.http.get<Producto[]>(this.baseUrl);
+  }
+
+  crearProducto(dto: CreateProductoDTO): Observable<Producto> {
+    return this.http.post<Producto>(this.baseUrl, dto);
+  }
+
+  actualizarProducto(id: number, dto: UpdateProductoDTO): Observable<Producto> {
+    return this.http.put<Producto>(`${this.baseUrl}/${id}`, dto);
+  }
+
+  eliminarProducto(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+}


### PR DESCRIPTION
## Summary
- create product and category models and DTOs
- add API services for productos and categorias
- implement product list with create/edit dialog
- implement category list with create/edit dialog
- register new routes for productos and categorias

## Testing
- `npm run lint`
- `npm test -- --browsers=ChromeHeadless --watch=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_684aafde7ab8832492708192febfafa7