### PR TITLE
Add productos and categorias components and routes

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -62,6 +62,22 @@ export const routes: Routes = [
           ).then((m) => m.ReporteCuentasPorCobrarComponent),
       },
 
+      // ====== RUTAS DE PRODUCTOS ======
+      {
+        path: 'productos',
+        loadComponent: () =>
+          import('./features/productos/pages/productos.component').then(
+            (m) => m.ProductosComponent,
+          ),
+      },
+      {
+        path: 'categorias',
+        loadComponent: () =>
+          import('./features/categorias/pages/categorias.component').then(
+            (m) => m.CategoriasComponent,
+          ),
+      },
+
       // ====== RUTAS DE PERFIL ======
       {
         path: 'profile',

--- a/frontend/src/app/features/categorias/pages/categorias.component.html
+++ b/frontend/src/app/features/categorias/pages/categorias.component.html
@@ -1,0 +1,4 @@
+<app-page-header title="Categorías"></app-page-header>
+<div class="container">
+  <p>Administración de categorías</p>
+</div>

--- a/frontend/src/app/features/categorias/pages/categorias.component.scss
+++ b/frontend/src/app/features/categorias/pages/categorias.component.scss
@@ -1,0 +1,3 @@
+.container {
+  padding: 1rem;
+}

--- a/frontend/src/app/features/categorias/pages/categorias.component.ts
+++ b/frontend/src/app/features/categorias/pages/categorias.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PageHeaderComponent } from 'src/app/shared/components/page-header/page-header.component';
+
+@Component({
+  selector: 'app-categorias',
+  standalone: true,
+  imports: [CommonModule, PageHeaderComponent],
+  templateUrl: './categorias.component.html',
+  styleUrls: ['./categorias.component.scss'],
+})
+export class CategoriasComponent {}

--- a/frontend/src/app/features/productos/pages/productos.component.html
+++ b/frontend/src/app/features/productos/pages/productos.component.html
@@ -1,0 +1,4 @@
+<app-page-header title="Productos"></app-page-header>
+<div class="container">
+  <p>Administración de productos</p>
+</div>

--- a/frontend/src/app/features/productos/pages/productos.component.scss
+++ b/frontend/src/app/features/productos/pages/productos.component.scss
@@ -1,0 +1,3 @@
+.container {
+  padding: 1rem;
+}

--- a/frontend/src/app/features/productos/pages/productos.component.ts
+++ b/frontend/src/app/features/productos/pages/productos.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PageHeaderComponent } from 'src/app/shared/components/page-header/page-header.component';
+
+@Component({
+  selector: 'app-productos',
+  standalone: true,
+  imports: [CommonModule, PageHeaderComponent],
+  templateUrl: './productos.component.html',
+  styleUrls: ['./productos.component.scss'],
+})
+export class ProductosComponent {}


### PR DESCRIPTION
## Summary
- create `ProductosComponent` and `CategoriasComponent`
- register new routes `productos` and `categorias`
- keep menu items pointing to those routes

## Testing
- `npm test` *(fails: ng not found)*
- `./mvnw -q test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684aafe046708324a91e05872fbac583