### PR TITLE
Add clientes CRUD with shared styles

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -41,6 +41,11 @@ export const routes: Routes = [
           import('./features/ventas/pages/ventas.component').then((m) => m.VentasComponent),
       },
       {
+        path: 'clientes',
+        loadComponent: () =>
+          import('./features/clientes/pages/clientes.component').then((m) => m.ClientesComponent),
+      },
+      {
         path: 'reporte-ventas',
         loadComponent: () =>
           import('./features/reportes/pages/reporte-ventas/reporte-ventas.component').then(

--- a/frontend/src/app/core/models/clientes/cliente.model.ts
+++ b/frontend/src/app/core/models/clientes/cliente.model.ts
@@ -1,4 +1,9 @@
 export interface Cliente {
   clienteId: number;
   nombre: string;
+  correo: string;
+  telefono?: string;
+  direccion?: string;
+  fechaRegistro: string;
+  activo: boolean;
 }

--- a/frontend/src/app/core/models/clientes/create-cliente-dto.model.ts
+++ b/frontend/src/app/core/models/clientes/create-cliente-dto.model.ts
@@ -1,0 +1,7 @@
+export interface CreateClienteDTO {
+  nombre: string;
+  correo: string;
+  telefono?: string;
+  direccion?: string;
+  creadoPorUsuarioId: number;
+}

--- a/frontend/src/app/core/models/clientes/update-cliente-dto.model.ts
+++ b/frontend/src/app/core/models/clientes/update-cliente-dto.model.ts
@@ -1,0 +1,6 @@
+export interface UpdateClienteDTO {
+  nombre: string;
+  correo: string;
+  telefono?: string;
+  direccion?: string;
+}

--- a/frontend/src/app/features/clientes/pages/clientes-create-edit-dialog.component.html
+++ b/frontend/src/app/features/clientes/pages/clientes-create-edit-dialog.component.html
@@ -1,0 +1,39 @@
+<h2 mat-dialog-title>{{ isEdit ? 'Editar Cliente' : 'Nuevo Cliente' }}</h2>
+<mat-dialog-content>
+  <form [formGroup]="form" (ngSubmit)="submit()" class="w-100">
+    <mat-form-field class="form-field-full" appearance="outline">
+      <mat-label>Nombre</mat-label>
+      <input matInput formControlName="nombre" required />
+      <mat-error *ngIf="form.get('nombre')?.hasError('required')">
+        El nombre es requerido
+      </mat-error>
+    </mat-form-field>
+
+    <mat-form-field class="form-field-full" appearance="outline">
+      <mat-label>Correo</mat-label>
+      <input matInput formControlName="correo" required />
+      <mat-error *ngIf="form.get('correo')?.hasError('required')">
+        El correo es requerido
+      </mat-error>
+      <mat-error *ngIf="form.get('correo')?.hasError('email')">
+        Correo inválido
+      </mat-error>
+    </mat-form-field>
+
+    <mat-form-field class="form-field-full" appearance="outline">
+      <mat-label>Teléfono</mat-label>
+      <input matInput formControlName="telefono" />
+    </mat-form-field>
+
+    <mat-form-field class="form-field-full" appearance="outline">
+      <mat-label>Dirección</mat-label>
+      <textarea matInput formControlName="direccion"></textarea>
+    </mat-form-field>
+  </form>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-flat-button color="primary" (click)="submit()" [disabled]="form.invalid">
+    Guardar
+  </button>
+  <button mat-flat-button (click)="cancelar()">Cancelar</button>
+</mat-dialog-actions>

--- a/frontend/src/app/features/clientes/pages/clientes-create-edit-dialog.component.scss
+++ b/frontend/src/app/features/clientes/pages/clientes-create-edit-dialog.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/frontend/src/app/features/clientes/pages/clientes-create-edit-dialog.component.ts
+++ b/frontend/src/app/features/clientes/pages/clientes-create-edit-dialog.component.ts
@@ -1,0 +1,88 @@
+import { Component, Inject, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+
+import { Cliente } from 'src/app/core/models/clientes/cliente.model';
+import { CreateClienteDTO } from 'src/app/core/models/clientes/create-cliente-dto.model';
+import { UpdateClienteDTO } from 'src/app/core/models/clientes/update-cliente-dto.model';
+import { ClientesApiService } from 'src/app/infrastructure/api/clientes/clientes-api.service';
+
+@Component({
+  selector: 'app-clientes-create-edit-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatSnackBarModule,
+  ],
+  templateUrl: './clientes-create-edit-dialog.component.html',
+  styleUrls: ['./clientes-create-edit-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ClientesCreateEditDialogComponent implements OnInit {
+  form!: FormGroup;
+  isEdit: boolean;
+
+  constructor(
+    private fb: FormBuilder,
+    private api: ClientesApiService,
+    private snackBar: MatSnackBar,
+    @Inject(MAT_DIALOG_DATA) public data: { cliente?: Cliente },
+    private dialogRef: MatDialogRef<ClientesCreateEditDialogComponent>,
+  ) {
+    this.isEdit = !!data.cliente;
+  }
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      nombre: [this.data.cliente?.nombre ?? '', Validators.required],
+      correo: [this.data.cliente?.correo ?? '', [Validators.required, Validators.email]],
+      telefono: [this.data.cliente?.telefono ?? ''],
+      direccion: [this.data.cliente?.direccion ?? ''],
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid) return;
+
+    if (this.isEdit && this.data.cliente) {
+      const dto: UpdateClienteDTO = this.form.value;
+      this.api.actualizarCliente(this.data.cliente.clienteId, dto).subscribe({
+        next: () => {
+          this.snackBar.open('Cliente actualizado correctamente', '', { duration: 3000 });
+          this.dialogRef.close(true);
+        },
+        error: (err: Error) => {
+          this.snackBar.open(`Error: ${err.message}`, '', { duration: 5000 });
+        },
+      });
+    } else {
+      const dto: CreateClienteDTO = {
+        ...this.form.value,
+        creadoPorUsuarioId: 1,
+      };
+      this.api.crearCliente(dto).subscribe({
+        next: () => {
+          this.snackBar.open('Cliente creado correctamente', '', { duration: 3000 });
+          this.dialogRef.close(true);
+        },
+        error: (err: Error) => {
+          this.snackBar.open(`Error: ${err.message}`, '', { duration: 5000 });
+        },
+      });
+    }
+  }
+
+  cancelar(): void {
+    this.dialogRef.close();
+  }
+}

--- a/frontend/src/app/features/clientes/pages/clientes.component.html
+++ b/frontend/src/app/features/clientes/pages/clientes.component.html
@@ -1,0 +1,58 @@
+<div class="row mb-3">
+  <mat-form-field class="col-12 col-md-6 form-field-full" appearance="outline">
+    <mat-label>Buscar cliente</mat-label>
+    <input #searchInput matInput (keyup)="filtrar($event)" placeholder="Nombre" />
+    <button *ngIf="dataSource.filter" matSuffix mat-icon-button aria-label="Limpiar búsqueda" (click)="clearFilter()">
+      <mat-icon>close</mat-icon>
+    </button>
+  </mat-form-field>
+</div>
+
+<mat-card>
+  <mat-card-header>
+    <mat-card-title>Listado de Clientes</mat-card-title>
+    <button mat-fab color="primary" class="fab-add" (click)="nuevoCliente()" aria-label="Nuevo Cliente">
+      <mat-icon>add</mat-icon>
+    </button>
+  </mat-card-header>
+
+  <mat-card-content class="table-container">
+    <div *ngIf="loading" class="spinner-container">
+      <mat-spinner></mat-spinner>
+    </div>
+
+    <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z1">
+      <ng-container matColumnDef="nombre">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Nombre</th>
+        <td mat-cell *matCellDef="let c">{{ c.nombre }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="correo">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Correo</th>
+        <td mat-cell *matCellDef="let c">{{ c.correo }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="telefono">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Teléfono</th>
+        <td mat-cell *matCellDef="let c">{{ c.telefono }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="acciones">
+        <th mat-header-cell *matHeaderCellDef>Acciones</th>
+        <td mat-cell *matCellDef="let c">
+          <button mat-icon-button color="primary" (click)="editarCliente(c)" aria-label="Editar">
+            <mat-icon>edit</mat-icon>
+          </button>
+          <button mat-icon-button color="warn" (click)="eliminarCliente(c.clienteId)" aria-label="Eliminar">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+
+    <mat-paginator [pageSizeOptions]="[10, 25, 50]" showFirstLastButtons></mat-paginator>
+  </mat-card-content>
+</mat-card>

--- a/frontend/src/app/features/clientes/pages/clientes.component.scss
+++ b/frontend/src/app/features/clientes/pages/clientes.component.scss
@@ -7,4 +7,3 @@ table {
   width: auto;
   min-width: 100%;
 }
-

--- a/frontend/src/app/features/clientes/pages/clientes.component.ts
+++ b/frontend/src/app/features/clientes/pages/clientes.component.ts
@@ -1,0 +1,116 @@
+import { Component, OnInit, ChangeDetectionStrategy, ViewChild, ElementRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatCardModule } from '@angular/material/card';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+import { Cliente } from 'src/app/core/models/clientes/cliente.model';
+import { ClientesApiService } from 'src/app/infrastructure/api/clientes/clientes-api.service';
+import { ClientesCreateEditDialogComponent } from './clientes-create-edit-dialog.component';
+
+@Component({
+  selector: 'app-clientes',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatSortModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDialogModule,
+    MatSnackBarModule,
+    MatCardModule,
+    MatProgressSpinnerModule,
+  ],
+  templateUrl: './clientes.component.html',
+  styleUrls: ['./clientes.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ClientesComponent implements OnInit {
+  dataSource = new MatTableDataSource<Cliente>();
+  loading = false;
+  displayedColumns = ['nombre', 'correo', 'telefono', 'acciones'];
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+  @ViewChild('searchInput') searchInput!: ElementRef<HTMLInputElement>;
+
+  constructor(
+    private api: ClientesApiService,
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar,
+  ) {}
+
+  ngOnInit(): void {
+    this.cargarClientes();
+  }
+
+  private cargarClientes(): void {
+    this.loading = true;
+    this.api.obtenerClientes().subscribe({
+      next: (data: Cliente[]) => {
+        this.dataSource.data = data.filter(c => c.activo);
+        this.dataSource.paginator = this.paginator;
+        this.dataSource.sort = this.sort;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+        this.snackBar.open('Error al cargar clientes', '', { duration: 3000 });
+      },
+    });
+  }
+
+  filtrar(event: Event): void {
+    const filtro = (event.target as HTMLInputElement).value.trim().toLowerCase();
+    this.dataSource.filter = filtro;
+  }
+
+  clearFilter(): void {
+    this.dataSource.filter = '';
+    this.searchInput.nativeElement.value = '';
+  }
+
+  nuevoCliente(): void {
+    const ref = this.dialog.open(ClientesCreateEditDialogComponent, {
+      width: '500px',
+      data: {},
+    });
+    ref.afterClosed().subscribe((created: boolean) => {
+      if (created) this.cargarClientes();
+    });
+  }
+
+  editarCliente(cliente: Cliente): void {
+    const ref = this.dialog.open(ClientesCreateEditDialogComponent, {
+      width: '500px',
+      data: { cliente },
+    });
+    ref.afterClosed().subscribe((updated: boolean) => {
+      if (updated) this.cargarClientes();
+    });
+  }
+
+  eliminarCliente(id: number): void {
+    this.api.eliminarCliente(id).subscribe({
+      next: () => {
+        this.snackBar.open('Cliente eliminado correctamente', '', { duration: 3000 });
+        this.cargarClientes();
+      },
+      error: (err: Error) => {
+        this.snackBar.open(`Error: ${err.message}`, '', { duration: 5000 });
+      },
+    });
+  }
+}

--- a/frontend/src/app/features/ventas/pages/detalle-venta-dialog.component.scss
+++ b/frontend/src/app/features/ventas/pages/detalle-venta-dialog.component.scss
@@ -1,5 +1,0 @@
-.spinner-container {
-  display: flex;
-  justify-content: center;
-  padding: var(--gutter);
-}

--- a/frontend/src/app/infrastructure/api/clientes/clientes-api.service.ts
+++ b/frontend/src/app/infrastructure/api/clientes/clientes-api.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Cliente } from 'src/app/core/models/clientes/cliente.model';
+import { CreateClienteDTO } from 'src/app/core/models/clientes/create-cliente-dto.model';
+import { UpdateClienteDTO } from 'src/app/core/models/clientes/update-cliente-dto.model';
 
 @Injectable({ providedIn: 'root' })
 export class ClientesApiService {
@@ -11,5 +13,21 @@ export class ClientesApiService {
 
   obtenerClientes(): Observable<Cliente[]> {
     return this.http.get<Cliente[]>(this.baseUrl);
+  }
+
+  obtenerCliente(id: number): Observable<Cliente> {
+    return this.http.get<Cliente>(`${this.baseUrl}/${id}`);
+  }
+
+  crearCliente(dto: CreateClienteDTO): Observable<Cliente> {
+    return this.http.post<Cliente>(this.baseUrl, dto);
+  }
+
+  actualizarCliente(id: number, dto: UpdateClienteDTO): Observable<Cliente> {
+    return this.http.put<Cliente>(`${this.baseUrl}/${id}`, dto);
+  }
+
+  eliminarCliente(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
   }
 }

--- a/frontend/src/styles/custom/_helpers.scss
+++ b/frontend/src/styles/custom/_helpers.scss
@@ -1,0 +1,20 @@
+.fab-add {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 1000;
+}
+
+.table-container {
+  overflow-x: auto;
+  position: relative;
+  min-height: 300px;
+}
+
+.spinner-container {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10;
+}

--- a/frontend/src/styles/custom/_index.scss
+++ b/frontend/src/styles/custom/_index.scss
@@ -1,4 +1,5 @@
 @use 'material';
+@use 'helpers';
 
 // ----------------------------------------------
 // Estilos para el diálogo de cambio de contraseña


### PR DESCRIPTION
## Summary
- create shared helper styles for tables, spinners and floating button
- reuse helper classes in ventas
- implement ClientesComponent with CRUD dialog
- extend ClientesApiService and models
- wire ClientesComponent into routing

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_684aafe116408324a19b7c574655cc36