### PR TITLE
Add sample tests for cliente flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node
 
-      - name: Instalar dependencias frontend
-        working-directory: frontend
-        run: npm ci
+        - name: Instalar dependencias frontend
+          working-directory: frontend
+          run: npm ci
 
-      - name: Linter del código frontend
-        working-directory: frontend
-        run: npm run lint
+        - name: Ejecutar pruebas del frontend
+          working-directory: frontend
+          run: npm test -- --watch=false --browsers=ChromeHeadless
+
+        - name: Linter del código frontend
+          working-directory: frontend
+          run: npm run lint
 
       - name: Compilar frontend en modo producción
         working-directory: frontend

--- a/backend/src/test/java/com/proyecto/erpventas/application/usecases/cliente/CreateClienteUseCaseTest.java
+++ b/backend/src/test/java/com/proyecto/erpventas/application/usecases/cliente/CreateClienteUseCaseTest.java
@@ -1,0 +1,62 @@
+package com.proyecto.erpventas.application.usecases.cliente;
+
+import com.proyecto.erpventas.application.dto.request.cliente.CreateClienteDTO;
+import com.proyecto.erpventas.domain.model.people.Cliente;
+import com.proyecto.erpventas.domain.model.people.Usuario;
+import com.proyecto.erpventas.infrastructure.repository.cliente.ClienteRepository;
+import com.proyecto.erpventas.infrastructure.repository.usuario.UserRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class CreateClienteUseCaseTest {
+
+    @Test
+    void createCliente_deberiaPersistirYRetornarCliente() {
+        ClienteRepository clienteRepo = mock(ClienteRepository.class);
+        UserRepository userRepo = mock(UserRepository.class);
+        CreateClienteUseCase useCase = new CreateClienteUseCase(clienteRepo, userRepo);
+
+        CreateClienteDTO dto = new CreateClienteDTO();
+        dto.setNombre("Juan");
+        dto.setCorreo("juan@example.com");
+        dto.setTelefono("123");
+        dto.setDireccion("dir");
+        dto.setCreadoPorUsuarioId(5);
+
+        Usuario creador = new Usuario();
+        creador.setUsuarioID(5);
+        when(userRepo.findById(5)).thenReturn(Optional.of(creador));
+        when(clienteRepo.existsByCorreo("juan@example.com")).thenReturn(false);
+
+        Cliente saved = new Cliente();
+        saved.setClienteId(1);
+        saved.setNombre("Juan");
+        when(clienteRepo.save(any(Cliente.class))).thenReturn(saved);
+
+        Cliente result = useCase.create(dto);
+
+        assertThat(result.getClienteId()).isEqualTo(1);
+        assertThat(result.getNombre()).isEqualTo("Juan");
+        verify(clienteRepo).save(any(Cliente.class));
+    }
+
+    @Test
+    void createCliente_correoExistente_deberiaLanzarExcepcion() {
+        ClienteRepository clienteRepo = mock(ClienteRepository.class);
+        UserRepository userRepo = mock(UserRepository.class);
+        CreateClienteUseCase useCase = new CreateClienteUseCase(clienteRepo, userRepo);
+
+        CreateClienteDTO dto = new CreateClienteDTO();
+        dto.setCorreo("dup@example.com");
+        when(clienteRepo.existsByCorreo("dup@example.com")).thenReturn(true);
+
+        assertThrows(RuntimeException.class, () -> useCase.create(dto));
+        verify(clienteRepo, never()).save(any());
+    }
+}

--- a/backend/src/test/java/com/proyecto/erpventas/infrastructure/controller/ClienteControllerTest.java
+++ b/backend/src/test/java/com/proyecto/erpventas/infrastructure/controller/ClienteControllerTest.java
@@ -1,0 +1,80 @@
+package com.proyecto.erpventas.infrastructure.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.proyecto.erpventas.application.dto.request.cliente.CreateClienteDTO;
+import com.proyecto.erpventas.application.usecases.cliente.*;
+import com.proyecto.erpventas.domain.model.people.Cliente;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ClienteController.class,
+    excludeAutoConfiguration = org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class)
+class ClienteControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private CreateClienteUseCase createUC;
+    @MockitoBean
+    private ListClientesUseCase listUC;
+    @MockitoBean
+    private GetClienteByIdUseCase getByIdUC;
+    @MockitoBean
+    private UpdateClienteUseCase updateUC;
+    @MockitoBean
+    private DeleteClienteUseCase deleteUC;
+
+    @Test
+    void getAll_deberiaRetornarLista() throws Exception {
+        Cliente cliente = new Cliente();
+        cliente.setClienteId(1);
+        cliente.setNombre("Juan");
+        when(listUC.listAll()).thenReturn(List.of(cliente));
+
+        mockMvc.perform(get("/api/clientes"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].clienteId").value(1))
+                .andExpect(jsonPath("$[0].nombre").value("Juan"));
+
+        verify(listUC).listAll();
+    }
+
+    @Test
+    void create_deberiaRetornarClienteCreado() throws Exception {
+        CreateClienteDTO dto = new CreateClienteDTO();
+        dto.setNombre("Juan");
+        dto.setCorreo("juan@example.com");
+        dto.setTelefono("123");
+        dto.setDireccion("dir");
+        dto.setCreadoPorUsuarioId(5);
+
+        Cliente saved = new Cliente();
+        saved.setClienteId(1);
+        saved.setNombre("Juan");
+        when(createUC.create(any(CreateClienteDTO.class))).thenReturn(saved);
+
+        mockMvc.perform(post("/api/clientes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.clienteId").value(1))
+                .andExpect(jsonPath("$.nombre").value("Juan"));
+
+        verify(createUC).create(any(CreateClienteDTO.class));
+    }
+}

--- a/frontend/src/app/features/ventas/pages/ventas-create-edit-dialog.component.spec.ts
+++ b/frontend/src/app/features/ventas/pages/ventas-create-edit-dialog.component.spec.ts
@@ -1,0 +1,47 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of } from 'rxjs';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { VentasCreateEditDialogComponent } from './ventas-create-edit-dialog.component';
+import { VentasApiService } from 'src/app/infrastructure/api/ventas/ventas-api.service';
+import { ClientesApiService } from 'src/app/infrastructure/api/clientes/clientes-api.service';
+import { MetodosPagoApiService } from 'src/app/infrastructure/api/metodos-pago/metodos-pago-api.service';
+
+describe('VentasCreateEditDialogComponent', () => {
+  let component: VentasCreateEditDialogComponent;
+  let fixture: ComponentFixture<VentasCreateEditDialogComponent>;
+  let mockVentasApi: jasmine.SpyObj<VentasApiService>;
+  let mockClientesApi: jasmine.SpyObj<ClientesApiService>;
+  let mockMetodosApi: jasmine.SpyObj<MetodosPagoApiService>;
+
+  beforeEach(waitForAsync(() => {
+    mockVentasApi = jasmine.createSpyObj('VentasApiService', ['crearVenta', 'actualizarVenta']);
+    mockClientesApi = jasmine.createSpyObj('ClientesApiService', ['obtenerClientes']);
+    mockMetodosApi = jasmine.createSpyObj('MetodosPagoApiService', ['obtenerMetodosPago']);
+
+    TestBed.configureTestingModule({
+      imports: [VentasCreateEditDialogComponent, ReactiveFormsModule],
+      providers: [
+        { provide: VentasApiService, useValue: mockVentasApi },
+        { provide: ClientesApiService, useValue: mockClientesApi },
+        { provide: MetodosPagoApiService, useValue: mockMetodosApi },
+        { provide: MatSnackBar, useValue: { open: () => {} } },
+        { provide: MatDialogRef, useValue: { close: () => {} } },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(VentasCreateEditDialogComponent);
+    component = fixture.componentInstance;
+    mockClientesApi.obtenerClientes.and.returnValue(of([]));
+    mockMetodosApi.obtenerMetodosPago.and.returnValue(of([]));
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/infrastructure/api/clientes/clientes-api.service.spec.ts
+++ b/frontend/src/app/infrastructure/api/clientes/clientes-api.service.spec.ts
@@ -1,0 +1,29 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ClientesApiService } from './clientes-api.service';
+import { Cliente } from 'src/app/core/models/clientes/cliente.model';
+
+describe('ClientesApiService', () => {
+  let service: ClientesApiService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ClientesApiService]
+    });
+    service = TestBed.inject(ClientesApiService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  it('obtenerClientes() debe hacer GET a /api/clientes', () => {
+    const dummy: Cliente[] = [{ clienteId: 1, nombre: 'C' }];
+    service.obtenerClientes().subscribe(res => expect(res).toEqual(dummy));
+
+    const req = http.expectOne(r => r.url.endsWith('/api/clientes'));
+    expect(req.request.method).toBe('GET');
+    req.flush(dummy);
+  });
+});


### PR DESCRIPTION
## Summary
- add JUnit tests for CreateClienteUseCase and ClienteController
- create Jasmine tests for ClientesApiService and VentasCreateEditDialogComponent
- run frontend tests in CI workflow

## Testing
- `mvn test` *(fails: Network is unreachable)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684aafe2e4a88324b0342a29e23ecc85