### PR TITLE
Add PayPal sandbox integration

### DIFF
--- a/backend/src/main/java/com/proyecto/erpventas/domain/model/inventory/PasarelaPago.java
+++ b/backend/src/main/java/com/proyecto/erpventas/domain/model/inventory/PasarelaPago.java
@@ -1,5 +1,22 @@
 package com.proyecto.erpventas.domain.model.inventory;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "PasarelasPago")
+@Getter
+@Setter
 public class PasarelaPago {
-    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pasarelaid")
+    private Integer pasarelaId;
+
+    @Column(name = "nombre", nullable = false)
+    private String nombre;
+
+    @Column(name = "activo", nullable = false)
+    private Boolean activo = true;
 }

--- a/backend/src/main/java/com/proyecto/erpventas/domain/model/sales/TransaccionPasarela.java
+++ b/backend/src/main/java/com/proyecto/erpventas/domain/model/sales/TransaccionPasarela.java
@@ -1,5 +1,48 @@
 package com.proyecto.erpventas.domain.model.sales;
 
+import com.proyecto.erpventas.domain.model.inventory.PasarelaPago;
+import com.proyecto.erpventas.domain.model.people.Usuario;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "TransaccionesPasarela")
+@Getter
+@Setter
 public class TransaccionPasarela {
-    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "transaccionid")
+    private Integer transaccionId;
+
+    @ManyToOne
+    @JoinColumn(name = "ventaid", nullable = false)
+    private Venta venta;
+
+    @ManyToOne
+    @JoinColumn(name = "pasarelaid", nullable = false)
+    private PasarelaPago pasarela;
+
+    @Column(name = "estado", nullable = false)
+    private String estado;
+
+    @Column(name = "fechatransaccion", nullable = false)
+    private LocalDateTime fechaTransaccion;
+
+    @Column(name = "monto", nullable = false)
+    private BigDecimal monto;
+
+    @Column(name = "referenciatransaccion", nullable = false)
+    private String referenciaTransaccion;
+
+    @ManyToOne
+    @JoinColumn(name = "iniciadaporusuarioid", nullable = false)
+    private Usuario iniciadaPorUsuario;
+
+    @Column(name = "activo", nullable = false)
+    private Boolean activo = true;
 }

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/configuration/PayPalConfig.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/configuration/PayPalConfig.java
@@ -1,0 +1,36 @@
+package com.proyecto.erpventas.infrastructure.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PayPalConfig {
+
+    @Value("${paypal.mode}")
+    private String mode;
+
+    @Value("${paypal.client-id}")
+    private String clientId;
+
+    @Value("${paypal.secret}")
+    private String secret;
+
+    @Value("${paypal.base-url}")
+    private String baseUrl;
+
+    public String getMode() {
+        return mode;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/paypal/PayPalClient.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/paypal/PayPalClient.java
@@ -1,0 +1,88 @@
+package com.proyecto.erpventas.infrastructure.paypal;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.proyecto.erpventas.infrastructure.configuration.PayPalConfig;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Component
+public class PayPalClient {
+
+    private final PayPalConfig config;
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public PayPalClient(PayPalConfig config) {
+        this.config = config;
+    }
+
+    public String obtainAccessToken() throws IOException, InterruptedException {
+        String credentials = Base64.getEncoder().encodeToString(
+                (config.getClientId() + ":" + config.getSecret()).getBytes(StandardCharsets.UTF_8));
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(config.getBaseUrl() + "/v1/oauth2/token"))
+                .header("Authorization", "Basic " + credentials)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString("grant_type=client_credentials"))
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() >= 200 && response.statusCode() < 300) {
+            JsonNode node = mapper.readTree(response.body());
+            return node.get("access_token").asText();
+        }
+        throw new RuntimeException("No se pudo obtener token de PayPal");
+    }
+
+    public String createOrder(String accessToken, BigDecimal amount) throws IOException, InterruptedException {
+        String body = """
+                {
+                  \"intent\": \"CAPTURE\",
+                  \"purchase_units\": [
+                    {\n                      \"amount\": {\n                        \"currency_code\": \"USD\",\n                        \"value\": \"%s\"\n                      }\n                    }
+                  ]
+                }
+                """.formatted(amount);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(config.getBaseUrl() + "/v2/checkout/orders"))
+                .header("Authorization", "Bearer " + accessToken)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() >= 200 && response.statusCode() < 300) {
+            JsonNode node = mapper.readTree(response.body());
+            return node.get("id").asText();
+        }
+        throw new RuntimeException("No se pudo crear la orden de PayPal");
+    }
+
+    public CaptureResult captureOrder(String accessToken, String orderId) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(config.getBaseUrl() + "/v2/checkout/orders/" + orderId + "/capture"))
+                .header("Authorization", "Bearer " + accessToken)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() >= 200 && response.statusCode() < 300) {
+            JsonNode node = mapper.readTree(response.body());
+            String status = node.get("status").asText();
+            JsonNode capture = node.get("purchase_units").get(0).get("payments").get("captures").get(0);
+            String txId = capture.get("id").asText();
+            BigDecimal value = new BigDecimal(capture.get("amount").get("value").asText());
+            return new CaptureResult(status, txId, value);
+        }
+        throw new RuntimeException("No se pudo capturar la orden de PayPal");
+    }
+
+    public record CaptureResult(String status, String transactionId, BigDecimal amount) {}
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/pasarela/PasarelaPagoRepository.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/pasarela/PasarelaPagoRepository.java
@@ -1,0 +1,15 @@
+package com.proyecto.erpventas.infrastructure.repository.pasarela;
+
+import com.proyecto.erpventas.domain.model.inventory.PasarelaPago;
+import java.util.List;
+import java.util.Optional;
+
+public interface PasarelaPagoRepository {
+    Optional<PasarelaPago> findByNombre(String nombre);
+    Optional<PasarelaPago> findById(Integer id);
+    PasarelaPago save(PasarelaPago pasarela);
+    List<PasarelaPago> findAll();
+    List<PasarelaPago> findAllByActivoTrue();
+    void deleteById(Integer id);
+    void softDeleteById(Integer id);
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/pasarela/PasarelaPagoRepositoryImpl.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/pasarela/PasarelaPagoRepositoryImpl.java
@@ -1,0 +1,59 @@
+package com.proyecto.erpventas.infrastructure.repository.pasarela;
+
+import com.proyecto.erpventas.domain.model.inventory.PasarelaPago;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class PasarelaPagoRepositoryImpl implements PasarelaPagoRepository {
+
+    private final SpringPasarelaPagoJpaRepository jpaRepository;
+
+    public PasarelaPagoRepositoryImpl(SpringPasarelaPagoJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<PasarelaPago> findByNombre(String nombre) {
+        return jpaRepository.findByNombre(nombre).filter(PasarelaPago::getActivo);
+    }
+
+    @Override
+    public Optional<PasarelaPago> findById(Integer id) {
+        return jpaRepository.findById(id.longValue()).filter(PasarelaPago::getActivo);
+    }
+
+    @Override
+    public PasarelaPago save(PasarelaPago pasarela) {
+        return jpaRepository.save(pasarela);
+    }
+
+    @Override
+    public List<PasarelaPago> findAll() {
+        return jpaRepository.findAllByActivoTrueOrderByNombreAsc();
+    }
+
+    @Override
+    public List<PasarelaPago> findAllByActivoTrue() {
+        return findAll();
+    }
+
+    @Override
+    public void softDeleteById(Integer id) {
+        Optional<PasarelaPago> opt = jpaRepository.findById(id.longValue());
+        if (opt.isPresent()) {
+            PasarelaPago p = opt.get();
+            p.setActivo(false);
+            jpaRepository.save(p);
+        } else {
+            throw new RuntimeException("Pasarela no encontrada");
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        softDeleteById(id);
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/pasarela/SpringPasarelaPagoJpaRepository.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/pasarela/SpringPasarelaPagoJpaRepository.java
@@ -1,0 +1,12 @@
+package com.proyecto.erpventas.infrastructure.repository.pasarela;
+
+import com.proyecto.erpventas.domain.model.inventory.PasarelaPago;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SpringPasarelaPagoJpaRepository extends JpaRepository<PasarelaPago, Long> {
+    Optional<PasarelaPago> findByNombre(String nombre);
+    List<PasarelaPago> findAllByActivoTrueOrderByNombreAsc();
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/transaccion/SpringTransaccionPasarelaJpaRepository.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/transaccion/SpringTransaccionPasarelaJpaRepository.java
@@ -1,0 +1,10 @@
+package com.proyecto.erpventas.infrastructure.repository.transaccion;
+
+import com.proyecto.erpventas.domain.model.sales.TransaccionPasarela;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SpringTransaccionPasarelaJpaRepository extends JpaRepository<TransaccionPasarela, Long> {
+    List<TransaccionPasarela> findAllByActivoTrueOrderByFechaTransaccionDesc();
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/transaccion/TransaccionPasarelaRepository.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/transaccion/TransaccionPasarelaRepository.java
@@ -1,0 +1,14 @@
+package com.proyecto.erpventas.infrastructure.repository.transaccion;
+
+import com.proyecto.erpventas.domain.model.sales.TransaccionPasarela;
+import java.util.List;
+import java.util.Optional;
+
+public interface TransaccionPasarelaRepository {
+    TransaccionPasarela save(TransaccionPasarela tx);
+    Optional<TransaccionPasarela> findById(Integer id);
+    List<TransaccionPasarela> findAll();
+    List<TransaccionPasarela> findAllByActivoTrue();
+    void deleteById(Integer id);
+    void softDeleteById(Integer id);
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/transaccion/TransaccionPasarelaRepositoryImpl.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/transaccion/TransaccionPasarelaRepositoryImpl.java
@@ -1,0 +1,54 @@
+package com.proyecto.erpventas.infrastructure.repository.transaccion;
+
+import com.proyecto.erpventas.domain.model.sales.TransaccionPasarela;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class TransaccionPasarelaRepositoryImpl implements TransaccionPasarelaRepository {
+
+    private final SpringTransaccionPasarelaJpaRepository jpaRepository;
+
+    public TransaccionPasarelaRepositoryImpl(SpringTransaccionPasarelaJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public TransaccionPasarela save(TransaccionPasarela tx) {
+        return jpaRepository.save(tx);
+    }
+
+    @Override
+    public Optional<TransaccionPasarela> findById(Integer id) {
+        return jpaRepository.findById(id.longValue()).filter(TransaccionPasarela::getActivo);
+    }
+
+    @Override
+    public List<TransaccionPasarela> findAll() {
+        return jpaRepository.findAllByActivoTrueOrderByFechaTransaccionDesc();
+    }
+
+    @Override
+    public List<TransaccionPasarela> findAllByActivoTrue() {
+        return findAll();
+    }
+
+    @Override
+    public void softDeleteById(Integer id) {
+        Optional<TransaccionPasarela> opt = jpaRepository.findById(id.longValue());
+        if (opt.isPresent()) {
+            TransaccionPasarela t = opt.get();
+            t.setActivo(false);
+            jpaRepository.save(t);
+        } else {
+            throw new RuntimeException("Transacción no encontrada");
+        }
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        softDeleteById(id);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -47,3 +47,11 @@ spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.Ph
 # ================================================================
 management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=always
+# ================================================================
+# PayPal Configuration
+# ================================================================
+paypal.mode=sandbox
+paypal.client-id=${PAYPAL_CLIENT_ID}
+paypal.secret=${PAYPAL_SECRET}
+paypal.base-url=https://api-m.sandbox.paypal.com
+

--- a/frontend/src/app/features/ventas/pages/create-edit-dialog/ventas-create-edit-dialog.component.html
+++ b/frontend/src/app/features/ventas/pages/create-edit-dialog/ventas-create-edit-dialog.component.html
@@ -45,11 +45,13 @@
     <!-- Eliminamos por completo el atributo disabled -->
     <input matInput type="number" formControlName="total" />
   </mat-form-field>
+
+  <div id="paypal-button-container" *ngIf="showPaypal"></div>
 </form>
 
 <mat-dialog-actions align="end">
   <button mat-button (click)="cancelar()">Cancelar</button>
-  <button mat-flat-button class="btn-submit" [disabled]="form.invalid" (click)="submit()">
+  <button mat-flat-button class="btn-submit" [disabled]="form.invalid || showPaypal" (click)="submit()">
     {{ isEdit ? 'Actualizar' : 'Crear' }}
   </button>
 </mat-dialog-actions>


### PR DESCRIPTION
## Summary
- add PayPal properties and configuration
- implement `PayPalClient` to call sandbox API
- expose PayPal endpoints in `VentaController`
- persist transactions via new repositories
- render PayPal button in ventas dialog

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506db713a483249a8fbeca31e9a5af