### PR TITLE
Add user management module

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -82,6 +82,13 @@ export const routes: Routes = [
             (m) => m.CategoriasComponent,
           ),
       },
+      {
+        path: 'usuarios',
+        loadComponent: () =>
+          import('./features/usuarios/pages/usuarios.component').then(
+            (m) => m.UsuariosComponent,
+          ),
+      },
 
       // ====== RUTAS DE PERFIL ======
       {

--- a/frontend/src/app/core/config/init-layout.config.ts
+++ b/frontend/src/app/core/config/init-layout.config.ts
@@ -80,7 +80,7 @@ export function initNgMateroLayoutFactory(
         icon: 'settings',
         type: 'sub',
         children: [
-          { route: 'usuarios', name: 'Usuarios', type: 'link' },
+          { route: 'usuarios', name: 'Usuarios', type: 'link', icon: 'group' },
           /* { route: 'metodos-pago', name: 'Métodos de Pago', type: 'link' },
           { route: 'pasarelas', name: 'Pasarelas de Pago', type: 'link' }, */
         ],

--- a/frontend/src/app/core/models/auth/update-user-dto.model.ts
+++ b/frontend/src/app/core/models/auth/update-user-dto.model.ts
@@ -1,0 +1,4 @@
+export interface UpdateUserDTO {
+  nombreUsuario: string;
+  email: string;
+}

--- a/frontend/src/app/core/models/auth/update-user-password-dto.model.ts
+++ b/frontend/src/app/core/models/auth/update-user-password-dto.model.ts
@@ -1,0 +1,4 @@
+export interface UpdateUserPasswordDTO {
+  currentPassword: string;
+  newPassword: string;
+}

--- a/frontend/src/app/features/usuarios/pages/cambiar-password-dialog/usuarios-cambiar-password-dialog.component.html
+++ b/frontend/src/app/features/usuarios/pages/cambiar-password-dialog/usuarios-cambiar-password-dialog.component.html
@@ -1,0 +1,18 @@
+<h2 mat-dialog-title>{{ 'usuarios.cambiar_password' | translate }}</h2>
+
+<form [formGroup]="form" (ngSubmit)="submit()" mat-dialog-content>
+  <mat-form-field appearance="outline" class="w-100 mb-3">
+    <mat-label>Contraseña Actual</mat-label>
+    <input matInput type="password" formControlName="currentPassword" />
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="w-100 mb-3">
+    <mat-label>Nueva Contraseña</mat-label>
+    <input matInput type="password" formControlName="newPassword" />
+  </mat-form-field>
+</form>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancelar()">Cancelar</button>
+  <button mat-flat-button class="btn-submit" [disabled]="form.invalid" (click)="submit()">Actualizar</button>
+</mat-dialog-actions>

--- a/frontend/src/app/features/usuarios/pages/cambiar-password-dialog/usuarios-cambiar-password-dialog.component.scss
+++ b/frontend/src/app/features/usuarios/pages/cambiar-password-dialog/usuarios-cambiar-password-dialog.component.scss
@@ -1,0 +1,42 @@
+@use '@angular/material' as mat;
+
+.w-100 {
+  width: 100%;
+}
+.mb-3 {
+  margin-bottom: var(--gutter);
+}
+
+.btn-submit {
+  @include mat.elevation(2);
+
+  background-color: var(--mat-sys-primary-container);
+  color: var(--mat-sys-on-primary-container) !important;
+
+  &:hover {
+    background-color: rgba(0, 123, 255, 0.85);
+    color: white !important;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    color: var(--mat-sys-on-primary-container) !important;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .btn-submit {
+    background-color: #3f51b5 !important;
+    color: #ffffff !important;
+
+    &:hover {
+      background-color: #5c6bc0 !important;
+      color: #ffffff !important;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      color: #ffffff !important;
+    }
+  }
+}

--- a/frontend/src/app/features/usuarios/pages/cambiar-password-dialog/usuarios-cambiar-password-dialog.component.ts
+++ b/frontend/src/app/features/usuarios/pages/cambiar-password-dialog/usuarios-cambiar-password-dialog.component.ts
@@ -1,0 +1,67 @@
+import { Component, Inject, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { UsuarioApiService } from 'src/app/infrastructure/api/usuario/usuario-api.service';
+import { UpdateUserPasswordDTO } from 'src/app/core/models/auth/update-user-password-dto.model';
+
+@Component({
+  selector: 'app-usuarios-cambiar-password-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatSnackBarModule,
+    TranslateModule,
+  ],
+  templateUrl: './usuarios-cambiar-password-dialog.component.html',
+  styleUrls: ['./usuarios-cambiar-password-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UsuariosCambiarPasswordDialogComponent implements OnInit {
+  form!: FormGroup;
+
+  constructor(
+    private fb: FormBuilder,
+    private api: UsuarioApiService,
+    private snackBar: MatSnackBar,
+    @Inject(MAT_DIALOG_DATA) public data: { userId: number },
+    private dialogRef: MatDialogRef<UsuariosCambiarPasswordDialogComponent>,
+  ) {}
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      currentPassword: ['', Validators.required],
+      newPassword: ['', Validators.required],
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid) return;
+
+    const dto: UpdateUserPasswordDTO = this.form.value;
+    this.api.cambiarPassword(this.data.userId, dto).subscribe({
+      next: () => {
+        this.snackBar.open('Contraseña actualizada correctamente', '', { duration: 3000 });
+        this.dialogRef.close(true);
+      },
+      error: (err: Error) => {
+        this.snackBar.open(`Error: ${err.message}`, '', { duration: 5000 });
+      },
+    });
+  }
+
+  cancelar(): void {
+    this.dialogRef.close();
+  }
+}

--- a/frontend/src/app/features/usuarios/pages/create-edit-dialog/usuarios-create-edit-dialog.component.html
+++ b/frontend/src/app/features/usuarios/pages/create-edit-dialog/usuarios-create-edit-dialog.component.html
@@ -1,0 +1,27 @@
+<h2 mat-dialog-title>
+  {{ isEdit ? ('usuarios.editar' | translate) + ' #' + (data.usuario?.usuarioID ?? '') : ('usuarios.nuevo' | translate) }}
+</h2>
+
+<form [formGroup]="form" (ngSubmit)="submit()" mat-dialog-content>
+  <mat-form-field appearance="outline" class="w-100 mb-3">
+    <mat-label>{{ 'usuarios.nombre_usuario' | translate }}</mat-label>
+    <input matInput formControlName="nombreUsuario" />
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="w-100 mb-3">
+    <mat-label>{{ 'usuarios.email' | translate }}</mat-label>
+    <input matInput formControlName="email" />
+  </mat-form-field>
+
+  <mat-form-field *ngIf="!isEdit" appearance="outline" class="w-100 mb-3">
+    <mat-label>{{ 'usuarios.contrasena' | translate }}</mat-label>
+    <input matInput type="password" formControlName="password" />
+  </mat-form-field>
+</form>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancelar()">Cancelar</button>
+  <button mat-flat-button class="btn-submit" [disabled]="form.invalid" (click)="submit()">
+    {{ isEdit ? 'Actualizar' : 'Crear' }}
+  </button>
+</mat-dialog-actions>

--- a/frontend/src/app/features/usuarios/pages/create-edit-dialog/usuarios-create-edit-dialog.component.scss
+++ b/frontend/src/app/features/usuarios/pages/create-edit-dialog/usuarios-create-edit-dialog.component.scss
@@ -1,0 +1,42 @@
+@use '@angular/material' as mat;
+
+.w-100 {
+  width: 100%;
+}
+.mb-3 {
+  margin-bottom: var(--gutter);
+}
+
+.btn-submit {
+  @include mat.elevation(2);
+
+  background-color: var(--mat-sys-primary-container);
+  color: var(--mat-sys-on-primary-container) !important;
+
+  &:hover {
+    background-color: rgba(0, 123, 255, 0.85);
+    color: white !important;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    color: var(--mat-sys-on-primary-container) !important;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .btn-submit {
+    background-color: #3f51b5 !important;
+    color: #ffffff !important;
+
+    &:hover {
+      background-color: #5c6bc0 !important;
+      color: #ffffff !important;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      color: #ffffff !important;
+    }
+  }
+}

--- a/frontend/src/app/features/usuarios/pages/create-edit-dialog/usuarios-create-edit-dialog.component.ts
+++ b/frontend/src/app/features/usuarios/pages/create-edit-dialog/usuarios-create-edit-dialog.component.ts
@@ -1,0 +1,98 @@
+import { Component, Inject, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { Usuario } from 'src/app/core/models/auth/usuario.model';
+import { UsuarioApiService, RegisterUserDTO } from 'src/app/infrastructure/api/usuario/usuario-api.service';
+import { UpdateUserDTO } from 'src/app/core/models/auth/update-user-dto.model';
+
+@Component({
+  selector: 'app-usuarios-create-edit-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatSnackBarModule,
+    TranslateModule,
+  ],
+  templateUrl: './usuarios-create-edit-dialog.component.html',
+  styleUrls: ['./usuarios-create-edit-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UsuariosCreateEditDialogComponent implements OnInit {
+  form!: FormGroup;
+  isEdit: boolean;
+
+  constructor(
+    private fb: FormBuilder,
+    private api: UsuarioApiService,
+    private snackBar: MatSnackBar,
+    @Inject(MAT_DIALOG_DATA) public data: { usuario?: Usuario },
+    private dialogRef: MatDialogRef<UsuariosCreateEditDialogComponent>,
+  ) {
+    this.isEdit = !!data.usuario;
+  }
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      nombreUsuario: [this.data.usuario?.nombreUsuario ?? '', Validators.required],
+      email: [this.data.usuario?.email ?? '', [Validators.required, Validators.email]],
+      password: [''],
+    });
+
+    if (this.isEdit) {
+      this.form.removeControl('password');
+    } else {
+      this.form.get('password')?.addValidators(Validators.required);
+    }
+  }
+
+  submit(): void {
+    if (this.form.invalid) return;
+
+    if (this.isEdit && this.data.usuario) {
+      const dto: UpdateUserDTO = {
+        nombreUsuario: this.form.value.nombreUsuario,
+        email: this.form.value.email,
+      };
+      this.api.updateUsuario(this.data.usuario.usuarioID, dto).subscribe({
+        next: () => {
+          this.snackBar.open('Usuario actualizado correctamente', '', { duration: 3000 });
+          this.dialogRef.close(true);
+        },
+        error: (err: Error) => {
+          this.snackBar.open(`Error: ${err.message}`, '', { duration: 5000 });
+        },
+      });
+    } else {
+      const dto: RegisterUserDTO = {
+        nombreUsuario: this.form.value.nombreUsuario,
+        email: this.form.value.email,
+        password: this.form.value.password,
+      };
+      this.api.register(dto).subscribe({
+        next: () => {
+          this.snackBar.open('Usuario creado correctamente', '', { duration: 3000 });
+          this.dialogRef.close(true);
+        },
+        error: (err: Error) => {
+          this.snackBar.open(`Error: ${err.message}`, '', { duration: 5000 });
+        },
+      });
+    }
+  }
+
+  cancelar(): void {
+    this.dialogRef.close();
+  }
+}

--- a/frontend/src/app/features/usuarios/pages/usuarios.component.html
+++ b/frontend/src/app/features/usuarios/pages/usuarios.component.html
@@ -1,0 +1,88 @@
+<div class="row mb-3 justify-content-between align-items-center">
+  <mat-form-field class="col-12 col-md-6 form-field-full" appearance="outline">
+    <mat-label>{{ 'usuarios.buscar' | translate }}</mat-label>
+    <input #searchInput matInput (keyup)="filtrarUsuario($event)" placeholder="{{ 'usuarios.nombre_usuario' | translate }}" />
+    <button *ngIf="dataSource.filter" matSuffix mat-icon-button aria-label="Limpiar búsqueda" (click)="clearFilter()">
+      <mat-icon>close</mat-icon>
+    </button>
+  </mat-form-field>
+  <div class="col-auto">
+    <button mat-fab color="primary" (click)="nuevoUsuario()" aria-label="{{ 'usuarios.nuevo' | translate }}">
+      <mat-icon>add</mat-icon>
+    </button>
+  </div>
+</div>
+
+<mat-card>
+  <mat-card-header>
+    <mat-card-title>{{ 'usuarios.titulo' | translate }}</mat-card-title>
+  </mat-card-header>
+
+  <mat-card-content class="table-container">
+    <div *ngIf="loading" class="spinner-container">
+      <mat-spinner></mat-spinner>
+    </div>
+
+    <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z1">
+      <ng-container matColumnDef="usuarioID">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>ID</th>
+        <td mat-cell *matCellDef="let u">{{ u.usuarioID }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="nombreUsuario">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'usuarios.nombre_usuario' | translate }}</th>
+        <td mat-cell *matCellDef="let u">{{ u.nombreUsuario }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="email">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'usuarios.email' | translate }}</th>
+        <td mat-cell *matCellDef="let u">{{ u.email }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="twoFA">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>2FA</th>
+        <td mat-cell *matCellDef="let u">
+          <mat-icon color="primary" *ngIf="u.twoFAEnabled">verified</mat-icon>
+          <mat-icon color="warn" *ngIf="!u.twoFAEnabled">highlight_off</mat-icon>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="fechaRegistro">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'usuarios.fecha_registro' | translate }}</th>
+        <td mat-cell *matCellDef="let u">{{ u.fechaRegistro | date:'shortDate' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="estado">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'usuarios.estado' | translate }}</th>
+        <td mat-cell *matCellDef="let u">
+          <span [ngClass]="u.activo ? 'text-success' : 'text-danger'">
+            {{ u.activo ? ('usuarios.activo' | translate) : ('usuarios.inactivo' | translate) }}
+          </span>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="acciones">
+        <th mat-header-cell *matHeaderCellDef>{{ 'usuarios.acciones' | translate }}</th>
+        <td mat-cell *matCellDef="let u">
+          <button *ngIf="u.activo" mat-icon-button color="primary" (click)="editarUsuario(u)" aria-label="Editar">
+            <mat-icon>edit</mat-icon>
+          </button>
+          <button *ngIf="u.activo" mat-icon-button color="accent" (click)="cambiarPassword(u)" aria-label="Cambiar contraseña">
+            <mat-icon>password</mat-icon>
+          </button>
+          <button *ngIf="u.activo" mat-icon-button color="warn" (click)="eliminarUsuario(u.usuarioID)" aria-label="Eliminar">
+            <mat-icon>delete</mat-icon>
+          </button>
+          <button *ngIf="!u.activo" mat-icon-button color="primary" (click)="restaurarUsuario(u.usuarioID)" aria-label="Restaurar">
+            <mat-icon>restore</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+
+    <mat-paginator [pageSizeOptions]="[10, 25, 50]" showFirstLastButtons></mat-paginator>
+  </mat-card-content>
+</mat-card>

--- a/frontend/src/app/features/usuarios/pages/usuarios.component.scss
+++ b/frontend/src/app/features/usuarios/pages/usuarios.component.scss
@@ -1,0 +1,31 @@
+@use '@angular/material' as mat;
+
+:host {
+  display: block;
+  padding: var(--gutter);
+}
+
+table {
+  width: auto;
+  min-width: 100%;
+}
+
+.table-container {
+  position: relative;
+}
+
+.spinner-container {
+  display: flex;
+  justify-content: center;
+  margin: 20px 0;
+}
+
+.text-success {
+  color: #2e7d32;
+  font-weight: 500;
+}
+
+.text-danger {
+  color: #c62828;
+  font-weight: 500;
+}

--- a/frontend/src/app/features/usuarios/pages/usuarios.component.ts
+++ b/frontend/src/app/features/usuarios/pages/usuarios.component.ts
@@ -1,0 +1,141 @@
+import { Component, OnInit, ChangeDetectionStrategy, ViewChild, ElementRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
+import { MatPaginatorModule, MatPaginator } from '@angular/material/paginator';
+import { MatSortModule, MatSort } from '@angular/material/sort';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatCardModule } from '@angular/material/card';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { Usuario } from 'src/app/core/models/auth/usuario.model';
+import { UsuarioApiService } from 'src/app/infrastructure/api/usuario/usuario-api.service';
+import { UsuariosCreateEditDialogComponent } from './create-edit-dialog/usuarios-create-edit-dialog.component';
+import { UsuariosCambiarPasswordDialogComponent } from './cambiar-password-dialog/usuarios-cambiar-password-dialog.component';
+
+@Component({
+  selector: 'app-usuarios',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatSortModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDialogModule,
+    MatSnackBarModule,
+    MatCardModule,
+    MatProgressSpinnerModule,
+    TranslateModule,
+  ],
+  templateUrl: './usuarios.component.html',
+  styleUrls: ['./usuarios.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UsuariosComponent implements OnInit {
+  dataSource = new MatTableDataSource<Usuario>();
+  loading = false;
+  displayedColumns = ['usuarioID', 'nombreUsuario', 'email', 'twoFA', 'fechaRegistro', 'estado', 'acciones'];
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+  @ViewChild('searchInput') searchInput!: ElementRef<HTMLInputElement>;
+
+  constructor(
+    private api: UsuarioApiService,
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar,
+  ) {}
+
+  ngOnInit(): void {
+    this.cargarUsuarios();
+  }
+
+  private cargarUsuarios(): void {
+    this.loading = true;
+    this.api.obtenerUsuarios().subscribe({
+      next: (data: Usuario[]) => {
+        this.dataSource.data = data;
+        this.dataSource.paginator = this.paginator;
+        this.dataSource.sort = this.sort;
+        this.dataSource.filterPredicate = (u: Usuario, filter: string) =>
+          u.nombreUsuario.toLowerCase().includes(filter) || u.email.toLowerCase().includes(filter);
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+        this.snackBar.open('Error al cargar usuarios', '', { duration: 3000 });
+      },
+    });
+  }
+
+  filtrarUsuario(event: Event): void {
+    const filtro = (event.target as HTMLInputElement).value.trim().toLowerCase();
+    this.dataSource.filter = filtro;
+  }
+
+  clearFilter(): void {
+    this.dataSource.filter = '';
+    this.searchInput.nativeElement.value = '';
+  }
+
+  nuevoUsuario(): void {
+    const ref = this.dialog.open(UsuariosCreateEditDialogComponent, {
+      width: '500px',
+      data: {},
+    });
+    ref.afterClosed().subscribe((created: boolean) => {
+      if (created) this.cargarUsuarios();
+    });
+  }
+
+  editarUsuario(usuario: Usuario): void {
+    const ref = this.dialog.open(UsuariosCreateEditDialogComponent, {
+      width: '500px',
+      data: { usuario },
+    });
+    ref.afterClosed().subscribe((updated: boolean) => {
+      if (updated) this.cargarUsuarios();
+    });
+  }
+
+  cambiarPassword(usuario: Usuario): void {
+    const ref = this.dialog.open(UsuariosCambiarPasswordDialogComponent, {
+      width: '400px',
+      data: { userId: usuario.usuarioID },
+    });
+    ref.afterClosed().subscribe();
+  }
+
+  eliminarUsuario(id: number): void {
+    this.api.eliminarUsuario(id).subscribe({
+      next: () => {
+        this.snackBar.open('Usuario eliminado correctamente', '', { duration: 3000 });
+        this.cargarUsuarios();
+      },
+      error: (err: Error) => {
+        this.snackBar.open(`Error: ${err.message}`, '', { duration: 5000 });
+      },
+    });
+  }
+
+  restaurarUsuario(id: number): void {
+    this.api.restaurarUsuario(id).subscribe({
+      next: () => {
+        this.snackBar.open('Usuario restaurado', '', { duration: 3000 });
+        this.cargarUsuarios();
+      },
+      error: (err) => {
+        this.snackBar.open(`Error: ${err.message}`, '', { duration: 5000 });
+      },
+    });
+  }
+}

--- a/frontend/src/app/infrastructure/api/usuario/usuario-api.service.ts
+++ b/frontend/src/app/infrastructure/api/usuario/usuario-api.service.ts
@@ -3,6 +3,8 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Usuario } from '../../../core/models/auth/usuario.model';
 import { TwoFactorSetupResponseDTO } from '../../../core/models/auth/twofactor-setup-response.dto';
+import { UpdateUserDTO } from '../../../core/models/auth/update-user-dto.model';
+import { UpdateUserPasswordDTO } from '../../../core/models/auth/update-user-password-dto.model';
 
 export interface RegisterUserDTO {
   nombreUsuario: string;
@@ -66,5 +68,21 @@ export class UsuarioApiService {
   obtenerUsuarios(): Observable<Usuario[]> {
     return this.http.get<Usuario[]>('/api/usuarios');
     // Endpoint que debe existir en tu backend.
+  }
+
+  updateUsuario(id: number, dto: UpdateUserDTO): Observable<Usuario> {
+    return this.http.put<Usuario>(`/api/users/${id}`, dto);
+  }
+
+  cambiarPassword(id: number, dto: UpdateUserPasswordDTO): Observable<void> {
+    return this.http.put<void>(`/api/users/${id}/password`, dto);
+  }
+
+  eliminarUsuario(id: number): Observable<string> {
+    return this.http.delete(`/api/users/${id}`, { responseType: 'text' });
+  }
+
+  restaurarUsuario(id: number): Observable<Usuario> {
+    return this.http.put<Usuario>(`/api/users/activate/${id}`, {});
   }
 }

--- a/frontend/src/assets/i18n/en-US.json
+++ b/frontend/src/assets/i18n/en-US.json
@@ -190,6 +190,25 @@
   "have_an_account": "Already have an account",
   "restore_defaults": "Restore defaults",
 
+  "usuarios": {
+    "titulo": "Users",
+    "nombre_usuario": "Username",
+    "email": "Email",
+    "contrasena": "Password",
+    "twofa_habilitado": "2FA Enabled",
+    "fecha_registro": "Registration Date",
+    "estado": "Status",
+    "acciones": "Actions",
+    "buscar": "Search user",
+    "nuevo": "New User",
+    "editar": "Edit User",
+    "cambiar_password": "Change password",
+    "eliminar": "Delete",
+    "restaurar": "Restore",
+    "activo": "Active",
+    "inactivo": "Inactive"
+  },
+
   "language": {
     "english": "English",
     "spanish": "Español",

--- a/frontend/src/assets/i18n/es-ES.json
+++ b/frontend/src/assets/i18n/es-ES.json
@@ -190,6 +190,25 @@
   "have_an_account": "¿Ya tienes una cuenta?",
   "restore_defaults": "Restablecer ajustes",
 
+  "usuarios": {
+    "titulo": "Usuarios",
+    "nombre_usuario": "Nombre de usuario",
+    "email": "Correo",
+    "contrasena": "Contraseña",
+    "twofa_habilitado": "2FA habilitado",
+    "fecha_registro": "Fecha de registro",
+    "estado": "Estado",
+    "acciones": "Acciones",
+    "buscar": "Buscar usuario",
+    "nuevo": "Nuevo Usuario",
+    "editar": "Editar Usuario",
+    "cambiar_password": "Cambiar contraseña",
+    "eliminar": "Eliminar",
+    "restaurar": "Restaurar",
+    "activo": "Activo",
+    "inactivo": "Inactivo"
+  },
+
   "language": {
     "english": "Inglés",
     "spanish": "Español",


### PR DESCRIPTION
## Summary
- create user update models
- expand usuario-api service with management operations
- add standalone Users component with dialogs for editing and password change
- wire new route and sidenav entry
- add i18n keys for Users module

## Testing
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510c2a9a3c8324a1d54aeb99debde2