### PR TITLE
Implement user roles support

### DIFF
--- a/backend/src/main/java/com/proyecto/erpventas/application/usecases/usuario/GetRolesPorUsuarioUseCase.java
+++ b/backend/src/main/java/com/proyecto/erpventas/application/usecases/usuario/GetRolesPorUsuarioUseCase.java
@@ -1,0 +1,21 @@
+package com.proyecto.erpventas.application.usecases.usuario;
+
+import com.proyecto.erpventas.domain.model.auth.Role;
+import com.proyecto.erpventas.infrastructure.repository.auth.RoleRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class GetRolesPorUsuarioUseCase {
+
+    private final RoleRepository roleRepository;
+
+    public GetRolesPorUsuarioUseCase(RoleRepository roleRepository) {
+        this.roleRepository = roleRepository;
+    }
+
+    public List<Role> obtenerRoles(Integer usuarioId) {
+        return roleRepository.findByUsuarioId(usuarioId);
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/domain/model/auth/Role.java
+++ b/backend/src/main/java/com/proyecto/erpventas/domain/model/auth/Role.java
@@ -1,0 +1,25 @@
+package com.proyecto.erpventas.domain.model.auth;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "Roles")
+@Getter
+@Setter
+public class Role {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "roleid")
+    private Integer roleId;
+
+    @Column(name = "nombre", nullable = false, unique = true)
+    private String nombre;
+
+    @Column(name = "descripcion")
+    private String descripcion;
+
+    @Column(name = "activo", nullable = false)
+    private Boolean activo = true;
+}

--- a/backend/src/main/java/com/proyecto/erpventas/domain/model/auth/UsuarioRol.java
+++ b/backend/src/main/java/com/proyecto/erpventas/domain/model/auth/UsuarioRol.java
@@ -1,0 +1,35 @@
+package com.proyecto.erpventas.domain.model.auth;
+
+import com.proyecto.erpventas.domain.model.people.Usuario;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "UsuarioRoles")
+@Getter
+@Setter
+public class UsuarioRol {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "usuarioroleid")
+    private Integer usuarioRoleId;
+
+    @ManyToOne
+    @JoinColumn(name = "usuarioid", nullable = false)
+    private Usuario usuario;
+
+    @ManyToOne
+    @JoinColumn(name = "roleid", nullable = false)
+    private Role role;
+
+    @Column(name = "fechaasignacion", updatable = false)
+    @CreationTimestamp
+    private LocalDateTime fechaAsignacion;
+
+    @Column(name = "activo", nullable = false)
+    private Boolean activo = true;
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/controller/Auth/UserController.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/controller/Auth/UserController.java
@@ -9,6 +9,7 @@ import com.proyecto.erpventas.application.usecases.usuario.ListUsersUseCase;
 import com.proyecto.erpventas.application.usecases.usuario.UpdateUserPasswordUseCase;
 import com.proyecto.erpventas.application.usecases.usuario.UpdateUserUseCase;
 import com.proyecto.erpventas.application.usecases.usuario.ActivateUserUseCase;
+import com.proyecto.erpventas.application.usecases.usuario.GetRolesPorUsuarioUseCase;
 import com.proyecto.erpventas.domain.model.people.Usuario;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,18 +28,21 @@ public class UserController {
     private final UpdateUserUseCase updateUserUC;
     private final DeleteUserUseCase deleteUserUC;
     private final ActivateUserUseCase activateUserUseCase;
+    private final GetRolesPorUsuarioUseCase getRolesPorUsuarioUseCase;
 
     @Autowired
     public UserController(ListUsersUseCase listUsersUC, 
     GetUserByIdUseCase getUserByIdUC,
             UpdateUserUseCase updateUserUC, 
             DeleteUserUseCase deleteUserUC,
-            ActivateUserUseCase activateUserUseCase) {
+            ActivateUserUseCase activateUserUseCase,
+            GetRolesPorUsuarioUseCase getRolesPorUsuarioUseCase) {
         this.listUsersUC = listUsersUC;
         this.getUserByIdUC = getUserByIdUC;
         this.updateUserUC = updateUserUC;
         this.deleteUserUC = deleteUserUC;
         this.activateUserUseCase = activateUserUseCase;
+        this.getRolesPorUsuarioUseCase = getRolesPorUsuarioUseCase;
     }
 
     @Autowired
@@ -112,5 +116,14 @@ public class UserController {
                 user.getFechaRegistro(),
                 user.getActivo());
         return ResponseEntity.ok(dto);
+    }
+
+    @GetMapping("/{id}/roles")
+    public ResponseEntity<List<String>> obtenerRoles(@PathVariable Integer id) {
+        List<String> roles = getRolesPorUsuarioUseCase.obtenerRoles(id)
+                .stream()
+                .map(r -> r.getNombre())
+                .toList();
+        return ResponseEntity.ok(roles);
     }
 }

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/auth/RoleRepository.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/auth/RoleRepository.java
@@ -1,0 +1,16 @@
+package com.proyecto.erpventas.infrastructure.repository.auth;
+
+import com.proyecto.erpventas.domain.model.auth.Role;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RoleRepository {
+    Optional<Role> findById(Integer id);
+    List<Role> findAll();
+    Role save(Role role);
+    Role saveAndFlush(Role role);
+    void deleteById(Integer id);
+    void softDeleteById(Integer id);
+    List<Role> findByUsuarioId(Integer usuarioId);
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/auth/RoleRepositoryImpl.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/auth/RoleRepositoryImpl.java
@@ -1,0 +1,68 @@
+package com.proyecto.erpventas.infrastructure.repository.auth;
+
+import com.proyecto.erpventas.domain.model.auth.Role;
+import com.proyecto.erpventas.domain.model.auth.UsuarioRol;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class RoleRepositoryImpl implements RoleRepository {
+
+    private final SpringRoleJpaRepository roleJpaRepository;
+    private final SpringUsuarioRolJpaRepository usuarioRolJpaRepository;
+
+    public RoleRepositoryImpl(SpringRoleJpaRepository roleJpaRepository,
+                              SpringUsuarioRolJpaRepository usuarioRolJpaRepository) {
+        this.roleJpaRepository = roleJpaRepository;
+        this.usuarioRolJpaRepository = usuarioRolJpaRepository;
+    }
+
+    @Override
+    public Optional<Role> findById(Integer id) {
+        return roleJpaRepository.findById(id.longValue());
+    }
+
+    @Override
+    public List<Role> findAll() {
+        return roleJpaRepository.findAll();
+    }
+
+    @Override
+    public Role save(Role role) {
+        return roleJpaRepository.save(role);
+    }
+
+    @Override
+    public Role saveAndFlush(Role role) {
+        return roleJpaRepository.saveAndFlush(role);
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        softDeleteById(id);
+    }
+
+    @Override
+    public void softDeleteById(Integer id) {
+        Optional<Role> opt = roleJpaRepository.findById(id.longValue());
+        if (opt.isPresent()) {
+            Role r = opt.get();
+            r.setActivo(false);
+            roleJpaRepository.save(r);
+        } else {
+            throw new RuntimeException("Rol no encontrado");
+        }
+    }
+
+    @Override
+    public List<Role> findByUsuarioId(Integer usuarioId) {
+        List<UsuarioRol> asignaciones = usuarioRolJpaRepository
+                .findAllByUsuario_UsuarioIDAndActivoTrue(usuarioId);
+        return asignaciones.stream()
+                .map(UsuarioRol::getRole)
+                .filter(Role::getActivo)
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/auth/SpringRoleJpaRepository.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/auth/SpringRoleJpaRepository.java
@@ -1,0 +1,7 @@
+package com.proyecto.erpventas.infrastructure.repository.auth;
+
+import com.proyecto.erpventas.domain.model.auth.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringRoleJpaRepository extends JpaRepository<Role, Long> {
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/auth/SpringUsuarioRolJpaRepository.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/auth/SpringUsuarioRolJpaRepository.java
@@ -1,0 +1,10 @@
+package com.proyecto.erpventas.infrastructure.repository.auth;
+
+import com.proyecto.erpventas.domain.model.auth.UsuarioRol;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SpringUsuarioRolJpaRepository extends JpaRepository<UsuarioRol, Long> {
+    List<UsuarioRol> findAllByUsuario_UsuarioIDAndActivoTrue(Integer usuarioId);
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/auth/UsuarioRolRepository.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/auth/UsuarioRolRepository.java
@@ -1,0 +1,16 @@
+package com.proyecto.erpventas.infrastructure.repository.auth;
+
+import com.proyecto.erpventas.domain.model.auth.UsuarioRol;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UsuarioRolRepository {
+    Optional<UsuarioRol> findById(Integer id);
+    List<UsuarioRol> findAll();
+    UsuarioRol save(UsuarioRol usuarioRol);
+    UsuarioRol saveAndFlush(UsuarioRol usuarioRol);
+    void deleteById(Integer id);
+    void softDeleteById(Integer id);
+    List<UsuarioRol> findAllByUsuarioId(Integer usuarioId);
+}

--- a/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/auth/UsuarioRolRepositoryImpl.java
+++ b/backend/src/main/java/com/proyecto/erpventas/infrastructure/repository/auth/UsuarioRolRepositoryImpl.java
@@ -1,0 +1,59 @@
+package com.proyecto.erpventas.infrastructure.repository.auth;
+
+import com.proyecto.erpventas.domain.model.auth.UsuarioRol;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class UsuarioRolRepositoryImpl implements UsuarioRolRepository {
+
+    private final SpringUsuarioRolJpaRepository jpaRepository;
+
+    public UsuarioRolRepositoryImpl(SpringUsuarioRolJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<UsuarioRol> findById(Integer id) {
+        return jpaRepository.findById(id.longValue());
+    }
+
+    @Override
+    public List<UsuarioRol> findAll() {
+        return jpaRepository.findAll();
+    }
+
+    @Override
+    public UsuarioRol save(UsuarioRol usuarioRol) {
+        return jpaRepository.save(usuarioRol);
+    }
+
+    @Override
+    public UsuarioRol saveAndFlush(UsuarioRol usuarioRol) {
+        return jpaRepository.saveAndFlush(usuarioRol);
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        softDeleteById(id);
+    }
+
+    @Override
+    public void softDeleteById(Integer id) {
+        Optional<UsuarioRol> opt = jpaRepository.findById(id.longValue());
+        if (opt.isPresent()) {
+            UsuarioRol ur = opt.get();
+            ur.setActivo(false);
+            jpaRepository.save(ur);
+        } else {
+            throw new RuntimeException("Asignación de rol no encontrada");
+        }
+    }
+
+    @Override
+    public List<UsuarioRol> findAllByUsuarioId(Integer usuarioId) {
+        return jpaRepository.findAllByUsuario_UsuarioIDAndActivoTrue(usuarioId);
+    }
+}

--- a/frontend/src/app/core/models/auth/usuario.model.ts
+++ b/frontend/src/app/core/models/auth/usuario.model.ts
@@ -6,6 +6,8 @@ export interface Usuario {
   fechaRegistro: string;        // Fecha de registro (ISO string)
   activo: boolean;              // Estado de activo (soft-delete)
 
+  roles?: string[];
+
   // Estas dos propiedades ya no serán obligatorias
   password?: string;
   secret2FA?: string;

--- a/frontend/src/app/features/usuarios/pages/usuarios.component.html
+++ b/frontend/src/app/features/usuarios/pages/usuarios.component.html
@@ -59,6 +59,13 @@
         <td mat-cell *matCellDef="let u">{{ u.email }}</td>
       </ng-container>
 
+      <ng-container matColumnDef="roles">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>
+          {{ 'usuarios.roles' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let u">{{ u.roles?.join(', ') }}</td>
+      </ng-container>
+
       <ng-container matColumnDef="twoFA">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>2FA</th>
         <td mat-cell *matCellDef="let u">

--- a/frontend/src/app/infrastructure/api/usuario/usuario-api.service.ts
+++ b/frontend/src/app/infrastructure/api/usuario/usuario-api.service.ts
@@ -71,6 +71,10 @@ export class UsuarioApiService {
     // Endpoint que debe existir en tu backend.
   }
 
+  obtenerRolesDeUsuario(id: number): Observable<string[]> {
+    return this.http.get<string[]>(`${this.usersUrl}/${id}/roles`);
+  }
+
   updateUsuario(id: number, dto: UpdateUserDTO): Observable<Usuario> {
     return this.http.put<Usuario>(`/api/users/${id}`, dto);
   }

--- a/frontend/src/assets/i18n/en-US.json
+++ b/frontend/src/assets/i18n/en-US.json
@@ -194,6 +194,7 @@
     "titulo": "Users",
     "nombre_usuario": "Username",
     "email": "Email",
+    "roles": "Roles",
     "contrasena": "Password",
     "twofa_habilitado": "2FA Enabled",
     "fecha_registro": "Registration Date",

--- a/frontend/src/assets/i18n/es-ES.json
+++ b/frontend/src/assets/i18n/es-ES.json
@@ -194,6 +194,7 @@
     "titulo": "Usuarios",
     "nombre_usuario": "Nombre de usuario",
     "email": "Correo",
+    "roles": "Roles",
     "contrasena": "Contraseña",
     "twofa_habilitado": "2FA habilitado",
     "fecha_registro": "Fecha de registro",


### PR DESCRIPTION
## Summary
- add Role and UsuarioRol entities
- create JPA repositories and interfaces for roles
- add GetRolesPorUsuarioUseCase and controller endpoint
- extend Angular user model with roles and fetch via API
- display assigned roles in users table
- update translations

## Testing
- `mvnw test` *(fails: Network is unreachable)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512d9cb67c8324b7430f00f3c59845