### PR TITLE
Add HTML documentation

### DIFF
--- a/api.html
+++ b/api.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>API REST</title>
+  <style>
+    body {font-family: Arial, sans-serif; margin:0; padding:0; background:#f4f4f4;}
+    nav {background:#003366; padding:10px;}
+    nav a {color:white; margin-right:15px; text-decoration:none;}
+    .container {max-width:900px; margin:20px auto; padding:20px; background:white;}
+    h1, h2 {color:#003366;}
+    table {border-collapse: collapse; width:100%;}
+    th, td {border:1px solid #ccc; padding:8px; text-align:left;}
+    th {background:#e0e0e0;}
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Introducción</a>
+    <a href="estructura.html">Estructura</a>
+    <a href="despliegue.html">Despliegue</a>
+    <a href="seguridad.html">Seguridad</a>
+    <a href="api.html">API</a>
+    <a href="base_datos.html">Base de datos</a>
+    <a href="contacto.html">Contacto</a>
+  </nav>
+  <div class="container">
+    <h1>Principales Endpoints</h1>
+    <table>
+      <tr><th>Método</th><th>Ruta</th><th>Descripción</th></tr>
+      <tr><td>POST</td><td>/api/auth/register</td><td>Crear usuario</td></tr>
+      <tr><td>POST</td><td>/api/auth/login</td><td>Iniciar sesión</td></tr>
+      <tr><td>POST</td><td>/api/auth/login-2fa</td><td>Validar código 2FA</td></tr>
+      <tr><td>GET</td><td>/api/users</td><td>Listar usuarios (protegido)</td></tr>
+      <tr><td>GET</td><td>/api/clientes</td><td>Listar clientes (protegido)</td></tr>
+      <tr><td>GET</td><td>/api/productos</td><td>Listar productos (protegido)</td></tr>
+      <tr><td>POST</td><td>/api/ventas</td><td>Registrar venta</td></tr>
+      <tr><td>GET</td><td>/api/reportes/facturacion-mensual</td><td>Reporte de facturación</td></tr>
+      <tr><td>GET</td><td>/api/metodos-pago</td><td>Métodos de pago</td></tr>
+    </table>
+    <p>Los endpoints marcados como protegidos requieren un token JWT válido.</p>
+  </div>
+</body>
+</html>

--- a/base_datos.html
+++ b/base_datos.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Base de Datos</title>
+  <style>
+    body {font-family: Arial, sans-serif; margin:0; padding:0; background:#f4f4f4;}
+    nav {background:#003366; padding:10px;}
+    nav a {color:white; margin-right:15px; text-decoration:none;}
+    .container {max-width:900px; margin:20px auto; padding:20px; background:white;}
+    h1, h2 {color:#003366;}
+    pre {background:#eee; padding:10px; overflow:auto;}
+    table {border-collapse: collapse; width:100%; margin-bottom:20px;}
+    th, td {border:1px solid #ccc; padding:8px; text-align:left;}
+    th {background:#e0e0e0;}
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Introducción</a>
+    <a href="estructura.html">Estructura</a>
+    <a href="despliegue.html">Despliegue</a>
+    <a href="seguridad.html">Seguridad</a>
+    <a href="api.html">API</a>
+    <a href="base_datos.html">Base de datos</a>
+    <a href="contacto.html">Contacto</a>
+  </nav>
+  <div class="container">
+    <h1>Modelo de Datos</h1>
+    <p>El sistema utiliza PostgreSQL y las tablas principales se muestran a continuación.</p>
+    <table>
+      <tr><th>Tabla</th><th>Descripción básica</th></tr>
+      <tr><td>Usuarios</td><td>Credenciales y datos para autenticación con 2FA.</td></tr>
+      <tr><td>Roles</td><td>Listado de roles asignables a usuarios.</td></tr>
+      <tr><td>Clientes</td><td>Información de clientes registrados.</td></tr>
+      <tr><td>Productos</td><td>Catálogo de productos disponibles.</td></tr>
+      <tr><td>Ventas</td><td>Registro de ventas realizadas.</td></tr>
+      <tr><td>DetalleVentas</td><td>Productos por venta con precios y cantidades.</td></tr>
+      <tr><td>Facturas</td><td>Facturación electrónica asociada a cada venta.</td></tr>
+      <tr><td>CuentasPorCobrar</td><td>Gestión de pagos pendientes.</td></tr>
+      <tr><td>Pagos</td><td>Pagos aplicados a cuentas por cobrar.</td></tr>
+      <tr><td>PasarelasPago</td><td>Configuración de pasarelas como PayPal.</td></tr>
+      <tr><td>TransaccionesPasarela</td><td>Historial de pagos procesados.</td></tr>
+    </table>
+    <p>Las relaciones clave son:</p>
+    <ul>
+      <li><strong>Ventas</strong> referencia a <strong>Clientes</strong> y <strong>MetodosPago</strong>.</li>
+      <li><strong>DetalleVentas</strong> referencia a <strong>Ventas</strong> y <strong>Productos</strong>.</li>
+      <li><strong>Facturas</strong> y <strong>CuentasPorCobrar</strong> se relacionan uno a uno con <strong>Ventas</strong>.</li>
+      <li><strong>Pagos</strong> se vincula a <strong>CuentasPorCobrar</strong>.</li>
+      <li><strong>TransaccionesPasarela</strong> enlaza <strong>Ventas</strong> con <strong>PasarelasPago</strong>.</li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/contacto.html
+++ b/contacto.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Contacto</title>
+  <style>
+    body {font-family: Arial, sans-serif; margin:0; padding:0; background:#f4f4f4;}
+    nav {background:#003366; padding:10px;}
+    nav a {color:white; margin-right:15px; text-decoration:none;}
+    .container {max-width:900px; margin:20px auto; padding:20px; background:white;}
+    h1, h2 {color:#003366;}
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Introducción</a>
+    <a href="estructura.html">Estructura</a>
+    <a href="despliegue.html">Despliegue</a>
+    <a href="seguridad.html">Seguridad</a>
+    <a href="api.html">API</a>
+    <a href="base_datos.html">Base de datos</a>
+    <a href="contacto.html">Contacto</a>
+  </nav>
+  <div class="container">
+    <h1>Contacto</h1>
+    <p>Para consultas sobre este proyecto puede comunicarse con el equipo de desarrollo:</p>
+    <ul>
+      <li>Correo electrónico: <a href="mailto:info@erpventas.local">info@erpventas.local</a></li>
+      <li>Repositorio: <a href="https://github.com/usuario/erp-ventas">github.com/usuario/erp-ventas</a></li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/despliegue.html
+++ b/despliegue.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Despliegue</title>
+  <style>
+    body {font-family: Arial, sans-serif; margin:0; padding:0; background:#f4f4f4;}
+    nav {background:#003366; padding:10px;}
+    nav a {color:white; margin-right:15px; text-decoration:none;}
+    .container {max-width:900px; margin:20px auto; padding:20px; background:white;}
+    h1, h2 {color:#003366;}
+    pre {background:#eee; padding:10px; overflow:auto;}
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Introducción</a>
+    <a href="estructura.html">Estructura</a>
+    <a href="despliegue.html">Despliegue</a>
+    <a href="seguridad.html">Seguridad</a>
+    <a href="api.html">API</a>
+    <a href="base_datos.html">Base de datos</a>
+    <a href="contacto.html">Contacto</a>
+  </nav>
+  <div class="container">
+    <h1>Despliegue local</h1>
+    <p>Para ejecutar todos los servicios de forma local se utiliza Docker Compose. Requisitos previos:</p>
+    <ul>
+      <li>Docker &gt;= 20.10 y Docker Compose &gt;= 2.20</li>
+      <li>Git para clonar el repositorio</li>
+      <li>Node.js 20 y Angular CLI si se ejecuta el frontend sin Docker</li>
+      <li>JDK 17 y Maven 3.9 si se ejecuta el backend manualmente</li>
+    </ul>
+    <h2>Uso de Docker Compose</h2>
+    <pre><code>docker compose up --build</code></pre>
+    <p>Este comando compila las imágenes y levanta PostgreSQL, el backend y el frontend. Los contenedores pueden ejecutarse en segundo plano usando <code>-d</code>.</p>
+    <h2>Ejecución manual</h2>
+    <p>Si prefieres correr cada módulo sin Docker:</p>
+    <pre><code>./mvnw spring-boot:run     # Backend
+npm install
+npm run start            # Frontend
+</code></pre>
+    <h2>Acceso al sistema</h2>
+    <ul>
+      <li>Frontend: <a href="http://localhost:4200">http://localhost:4200</a></li>
+      <li>API backend: <a href="http://localhost:8080/api">http://localhost:8080/api</a></li>
+      <li>Swagger UI: <a href="http://localhost:8080/swagger-ui/">http://localhost:8080/swagger-ui/</a></li>
+      <li>Base de datos: <code>localhost:5432</code> (usuario <code>erp_user</code> / contraseña <code>erp_pass</code>)</li>
+    </ul>
+    <h2>Despliegue en producción</h2>
+    <p>Se recomienda el archivo <code>docker-compose.prod.yml</code> para producción:</p>
+    <pre><code>docker compose -f docker-compose.prod.yml up -d</code></pre>
+  </div>
+</body>
+</html>

--- a/estructura.html
+++ b/estructura.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Estructura del Proyecto</title>
+  <style>
+    body {font-family: Arial, sans-serif; margin:0; padding:0; background:#f4f4f4;}
+    nav {background:#003366; padding:10px;}
+    nav a {color:white; margin-right:15px; text-decoration:none;}
+    .container {max-width:900px; margin:20px auto; padding:20px; background:white;}
+    h1, h2 {color:#003366;}
+    pre {background:#eee; padding:10px; overflow:auto;}
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Introducción</a>
+    <a href="estructura.html">Estructura</a>
+    <a href="despliegue.html">Despliegue</a>
+    <a href="seguridad.html">Seguridad</a>
+    <a href="api.html">API</a>
+    <a href="base_datos.html">Base de datos</a>
+    <a href="contacto.html">Contacto</a>
+  </nav>
+  <div class="container">
+    <h1>Estructura del Proyecto</h1>
+    <p>El repositorio se organiza siguiendo la arquitectura hexagonal. A grandes rasgos, las carpetas principales son:</p>
+    <pre><code>erp-ventas/
+├── backend/                  # Backend Java con Spring Boot
+│   ├── application/          # Casos de uso (lógica de aplicación)
+│   ├── domain/               # Entidades y puertos
+│   ├── infrastructure/       # Adaptadores REST, Repos, Seguridad
+│   ├── resources/            # yml, reportes Jasper, etc.
+│   ├── Dockerfile
+│   └── pom.xml
+│
+├── frontend/                 # Frontend Angular
+│   ├── app/                  # Features, componentes, core, shared
+│   ├── assets/               # Recursos gráficos y estáticos
+│   ├── environments/         # Configuración por entorno
+│   ├── Dockerfile
+│   ├── angular.json
+│   └── package.json
+│
+├── db/                       # SQL de migración, configuración Flyway
+│   ├── sql/
+│   └── flyway.conf
+│
+├── docker-compose.yml        # Orquestación de todos los servicios
+└── README.md                 # Documentación general
+</code></pre>
+    <p>El backend implementa puertos y adaptadores para mantener la lógica de dominio aislada. El frontend sigue un enfoque modular por características.</p>
+  </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>ERP Ventas - Documentación</title>
+  <style>
+    body {font-family: Arial, sans-serif; margin:0; padding:0; background:#f4f4f4;}
+    nav {background:#003366; padding:10px;}
+    nav a {color:white; margin-right:15px; text-decoration:none;}
+    .container {max-width:900px; margin:20px auto; padding:20px; background:white;}
+    h1, h2 {color:#003366;}
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Introducción</a>
+    <a href="estructura.html">Estructura</a>
+    <a href="despliegue.html">Despliegue</a>
+    <a href="seguridad.html">Seguridad</a>
+    <a href="api.html">API</a>
+    <a href="base_datos.html">Base de datos</a>
+    <a href="contacto.html">Contacto</a>
+  </nav>
+  <div class="container">
+    <h1>Introducción</h1>
+    <p>ERP Ventas es un sistema de gestión de ventas y facturación electrónica. Facilita la administración de clientes, ventas, cuentas por cobrar y reportes empresariales.</p>
+    <p>El proyecto sigue una arquitectura robusta basada en principios Clean Architecture y SOLID, dividida en backend y frontend que se comunican mediante API REST.</p>
+    <h2>Características principales</h2>
+    <ul>
+      <li>Backend: Spring Boot 3.4.4, PostgreSQL, JasperReports, JWT y 2FA.</li>
+      <li>Frontend: Angular 19 con Angular Material.</li>
+      <li>Arquitectura hexagonal en ambos módulos.</li>
+      <li>Contenerización completa con Docker y Docker Compose.</li>
+      <li>Documentación de API generada con Swagger/OpenAPI.</li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/seguridad.html
+++ b/seguridad.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Seguridad</title>
+  <style>
+    body {font-family: Arial, sans-serif; margin:0; padding:0; background:#f4f4f4;}
+    nav {background:#003366; padding:10px;}
+    nav a {color:white; margin-right:15px; text-decoration:none;}
+    .container {max-width:900px; margin:20px auto; padding:20px; background:white;}
+    h1, h2 {color:#003366;}
+    pre {background:#eee; padding:10px; overflow:auto;}
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Introducción</a>
+    <a href="estructura.html">Estructura</a>
+    <a href="despliegue.html">Despliegue</a>
+    <a href="seguridad.html">Seguridad</a>
+    <a href="api.html">API</a>
+    <a href="base_datos.html">Base de datos</a>
+    <a href="contacto.html">Contacto</a>
+  </nav>
+  <div class="container">
+    <h1>Seguridad</h1>
+    <p>La autenticación se basa en tokens JWT emitidos por el backend después del inicio de sesión. Se implementa además la verificación en dos pasos (2FA) usando TOTP compatible con Google Authenticator.</p>
+    <h2>Flujo general</h2>
+    <ol>
+      <li>El usuario se registra con nombre de usuario, correo y contraseña.</li>
+      <li>Si el usuario habilita 2FA, recibe un código QR con la clave secreta.</li>
+      <li>En cada inicio de sesión se valida la contraseña y, si corresponde, el código 2FA.</li>
+      <li>Al autenticarse correctamente se genera un JWT que incluye los roles del usuario.</li>
+    </ol>
+    <h2>Roles</h2>
+    <p>Los roles determinan el acceso a los distintos endpoints protegidos. El token JWT porta esta información para su validación.</p>
+    <h2>Endpoints relevantes</h2>
+    <pre><code>POST /api/auth/register      # Crear usuario
+POST /api/auth/login         # Iniciar sesión (puede requerir 2FA)
+POST /api/auth/login-2fa     # Validar código 2FA y obtener JWT
+POST /api/auth/2fa-secret    # Generar secreto y QR para 2FA
+POST /api/auth/verify-2fa    # Verificar código 2FA
+</code></pre>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` for overview
- add `estructura.html` with project layout
- add `despliegue.html` for Docker instructions
- add `seguridad.html` describing JWT and 2FA
- add `api.html` table of endpoints
- add `base_datos.html` describing tables
- add `contacto.html` with contact info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851cff82f348324abb0b81b1cd5905f